### PR TITLE
Allow for switching between handlebars v3 and v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
-const Handlebars = require('handlebars');
+const HandlebarsV3 = require('handlebars');
+const HandlebarsV4 = require('@bigcommerce/handlebars-v4');
 const helpers = require('@bigcommerce/stencil-paper-handlebars-helpers');
 
 const handlebarsOptions = {
@@ -16,9 +17,20 @@ class HandlebarsRenderer {
     *
     * @param {Object} siteSettings - Global site settings, passed to helpers
     * @param {Object} themeSettings - Theme settings (configuration), passed to helpers
+    * @param {String} hbVersion - Which version of handlebars to use. One of ['v3', 'v4'] - defaults to 'v3'.
     */
-    constructor(siteSettings, themeSettings) {
-        this.handlebars = Handlebars.create();
+    constructor(siteSettings, themeSettings, hbVersion) {
+        // Figure out which version of Handlebars to use.
+        switch(hbVersion) {
+            case 'v4':
+                this.handlebars = HandlebarsV4.create();
+                break;
+            case 'v3':
+            default:
+                this.handlebars = HandlebarsV3.create();
+                break;
+        }
+
         this._translator = null;
         this._decorators = [];
         this._contentRegions = {};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/bigcommerce/paper-handlebars",
   "dependencies": {
     "@bigcommerce/stencil-paper-handlebars-helpers": "bigcommerce/paper-handlebars-helpers",
+    "@bigcommerce/handlebars-v4": "bigcommerce/handlebars-v4",
     "handlebars": "3.0.3",
     "lodash": "^3.6.0"
   },

--- a/spec/index.js
+++ b/spec/index.js
@@ -11,6 +11,26 @@ const beforeEach = lab.beforeEach;
 const Handlebars = require('handlebars');
 const HandlebarsRenderer = require('../index');
 
+describe('switching handlebars versions', () => {
+    it('defaults to v3', done => {
+        const renderer = new HandlebarsRenderer();
+        expect(renderer.handlebars.VERSION.substring(0, 1)).to.equal('3');
+        done();
+    });
+
+    it('can load v3', done => {
+        const renderer = new HandlebarsRenderer({}, {}, 'v3');
+        expect(renderer.handlebars.VERSION.substring(0, 1)).to.equal('3');
+        done();
+    });
+
+    it('can load v4', done => {
+        const renderer = new HandlebarsRenderer({}, {}, 'v4');
+        expect(renderer.handlebars.VERSION.substring(0, 1)).to.equal('4');
+        done();
+    });
+});
+
 describe('helper registration', () => {
     let renderer;
 


### PR DESCRIPTION
## What? Why?
* Allow for switching between handlebars v3 and v4
* We use a smaller wrapper for Handlebars [handlebars-v4](https://github.com/bigcommerce/handlebars-v4) to be able to load both versions side by side.
* This method allows us to move the helpers back into this repo and simplify things quite a bit.

## How was it tested?
`npm test`

----

cc @bigcommerce/storefront-team
