### PR TITLE
Remove references to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # paper-handlebars
 [![Build Status](https://travis-ci.org/bigcommerce/paper-handlebars.svg?branch=master)](https://travis-ci.org/bigcommerce/paper-handlebars)
 
-*paper-handlebars* is a plugin for [Paper](http://github.com/bigcommerce/paper). Its duty is to render pages and strings using the [Handlebars](http://handlebarsjs.com/) v3 template engine.
+*paper-handlebars* is a plugin for [Paper](http://github.com/bigcommerce/paper). Its duty is to render pages and strings using the [Handlebars](http://handlebarsjs.com/) template engine.
 
 ## Helpers Reference
 See the [Stencil API Reference](https://stencil.bigcommerce.com/docs/handlebars-helpers-reference) for documentation on the available helpers.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const handlebarsOptions = {
 };
 
 // HandlebarsRenderer implements the interface Paper requires for its
-// rendering needs, and does so with Handlebars v3.
+// rendering needs, and does so with Handlebars.
 class HandlebarsRenderer {
     /**
     * Constructor

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
   "version": "1.0.0",
-  "description": "A paper plugin to render pages using Handlebars.js v3",
+  "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",
   "license": "BSD-4-Clause",


### PR DESCRIPTION
## What? Why?
* We now render with either v3 or v4

## How was it tested?
Just doc changes

----

cc @bigcommerce/storefront-team
