### PR TITLE
Add better error handling

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,39 @@
+'use strict';
+
+class Logger {
+    constructor() {}
+
+    emerg(message) {
+        console.error(message);
+    }
+
+    alert(message) {
+        console.error(message);
+    }
+
+    crit(message) {
+        console.error(message);
+    }
+
+    error(message) {
+        console.error(message);
+    }
+
+    warn(message) {
+        console.warn(message);
+    }
+
+    notice(message) {
+        console.info(message);
+    }
+
+    info(message) {
+        console.info(message);
+    }
+
+    debug(message) {
+        console.log(message);
+    }
+}
+
+module.exports = Logger;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "code": "~4.0.0",
     "eslint": "~4.10.0",
+    "intercept-stdout": "^0.1.2",
     "lab": "~13.0.4",
     "sinon": "~2.1.0"
   }

--- a/spec/lib/logger.js
+++ b/spec/lib/logger.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const expect = Code.expect;
+const it = lab.it;
+const describe = lab.describe;
+const beforeEach = lab.beforeEach;
+
+const Logger = require('../../lib/logger');
+const capture = require('../spec-helpers').capture;
+
+describe('Logger', () => {
+    const message = "The cheapest, fastest, and most reliable components are those that aren't there."
+    let logger;
+
+    beforeEach(done => {
+        logger = new Logger();
+        done();
+    });
+
+    it('should log info', done => {
+        let captured = capture(() => {
+            logger.info(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log notice', done => {
+        let captured = capture(() => {
+            logger.notice(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log warn', done => {
+        let captured = capture(() => {
+            logger.warn(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log error', done => {
+        let captured = capture(() => {
+            logger.error(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log crit', done => {
+        let captured = capture(() => {
+            logger.crit(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log alert', done => {
+        let captured = capture(() => {
+            logger.alert(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log emerg', done => {
+        let captured = capture(() => {
+            logger.emerg(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+
+    it('should log debug', done => {
+        let captured = capture(() => {
+            logger.debug(message);
+        });
+
+        expect(captured).to.equal(`${message}\n`);
+        done();
+    });
+});

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -24,8 +24,23 @@ function render(template, context, siteSettings, themeSettings, templates) {
     return renderer.render(template, context);
 }
 
+// Call the callback while capturing output to stdout
+function capture(callback) {
+    let captured = '';
+    let intercept = require("intercept-stdout");
+    let unhook_intercept = intercept(function(text) {
+        captured += text;
+    });
+
+    callback();
+
+    unhook_intercept();
+    return captured;
+}
+
 module.exports = {
     buildRenderer,
     renderString,
     render,
+    capture,
 };


### PR DESCRIPTION
## What? Why?
* Add error handling around restoring precompiled templates, rendering templates, compiling templates, looking up templates
* Update addTemplates so it can handle a mix of precompiled templates and raw template strings
* Better detection of precompiled templates before doing a potentially dangerous eval.
* Add logger and ability for caller to set a logger

## How was it tested?
`npm test`

----

cc @bigcommerce/storefront-team
