### PR TITLE
STRF-4420: Add deferred access to siteSettings and themeSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,9 @@
   and logging. This gives the caller the opportunity to take action based on
   the error condition.
 - Remove logging interface since we don't use it anymore.
+
+## 3.0.0
+- Change addContent() to setContent() for consistency with other setters.
+- Add getter and setter for siteSettings and themeSettings, and change helper context
+  to use a bound function for accessing these data to allow for deferred setting.
+  Callers should no longer access siteSettings and themeSettings directly.

--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -56,7 +56,7 @@ const factory = globals => {
             googleFonts = [],
             linkElements = [];
 
-        _.each(globals.themeSettings, function (value, key) {
+        _.each(globals.getThemeSettings(), function (value, key) {
             var split;
 
             if (fontKeyFormat.test(key)) {

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 const factory = globals => {
     return function(image, presetName, defaultImageUrl) {
         var sizeRegex = /^(\d+?)x(\d+?)$/g;
-        var settings = globals.themeSettings || {};
+        var settings = globals.getThemeSettings() || {};
         var presets = settings._images;
         var size;
         var width;

--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -2,10 +2,13 @@
 
 // Return a function that can be used to translate paths to cdn paths
 module.exports = globals => {
-    const cdnUrl = globals.siteSettings['cdn_url'] || '';
-    const versionId = globals.siteSettings['theme_version_id'];
-    const editSessionId = globals.siteSettings['theme_session_id'];
-    const cdnSettings = globals.themeSettings.cdn;
+    const siteSettings = globals.getSiteSettings();
+    const themeSettings = globals.getThemeSettings();
+
+    const cdnUrl = siteSettings.cdn_url || '';
+    const versionId = siteSettings.theme_version_id;
+    const editSessionId = siteSettings.theme_session_id;
+    const cdnSettings = themeSettings.cdn;
 
     /**
      * Add CDN base url to the relative path

--- a/helpers/money.js
+++ b/helpers/money.js
@@ -18,7 +18,8 @@ function numberFormat(value, n, s, c) {
 
 const factory = globals => {
     return function(value) {
-        var money = globals.siteSettings.money;
+        const siteSettings = globals.getSiteSettings();
+        const money = siteSettings.money;
 
         if (!_.isNumber(value)) {
             return '';

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -5,10 +5,12 @@ const buildCDNHelper = require('./lib/cdnify');
 
 const factory = globals => {
     const cdnify = buildCDNHelper(globals);
+    const siteSettings = globals.getSiteSettings();
+    const configId = siteSettings.theme_config_id;
 
     return function(assetPath) {
         const options = arguments[arguments.length - 1];
-        const configId = globals.siteSettings['theme_config_id'];
+
         // append the configId only if the asset path starts with assets/css/
         const path = configId && assetPath.match(/^\/?assets\/css\//)
             ? assetPath.replace(/\.css$/, `-${configId}.css`)

--- a/index.js
+++ b/index.js
@@ -49,15 +49,17 @@ class HandlebarsRenderer {
                 break;
         }
 
-        this._translator = null;
-        this._decorators = [];
-        this._contentRegions = {};
+        this.setSiteSettings(siteSettings || {});
+        this.setThemeSettings(themeSettings || {});
+        this.setTranslator(null);
+        this.setContent({});
+        this.resetDecorators();
 
         // Build global context for helpers
         this.helperContext = {
-            siteSettings: siteSettings || {},
-            themeSettings: themeSettings || {},
             handlebars: this.handlebars,
+            getSiteSettings: this.getSiteSettings.bind(this),
+            getThemeSettings: this.getThemeSettings.bind(this),
             getTranslator: this.getTranslator.bind(this),
             getContent: this.getContent.bind(this),
             storage: {}, // global storage used by helpers to keep state
@@ -72,7 +74,7 @@ class HandlebarsRenderer {
     /**
      * Set the paper.Translator instance used to translate strings in helpers.
      *
-     * @param {Translator} A paper.Translator instance used to translate strings in helpers
+     * @param {Translator} translator A paper.Translator instance used to translate strings in helpers
      */
     setTranslator(translator) {
         this._translator = translator;
@@ -80,9 +82,81 @@ class HandlebarsRenderer {
 
     /**
      * Get the paper.Translator instance used to translate strings in helpers.
+     *
+     * @return {Translator} A paper.Translator instance used to translate strings in helpers
      */
     getTranslator() {
         return this._translator;
+    };
+
+    /**
+     * Set the siteSettings object containing global site settings.
+     *
+     * @param {object} settings An object containing global site settings.
+     */
+    setSiteSettings(settings) {
+        this._siteSettings = settings;
+    };
+
+    /**
+     * Get the siteSettings object containing global site settings.
+     *
+     * @return {object} settings An object containing global site settings.
+     */
+    getSiteSettings() {
+        return this._siteSettings;
+    };
+
+    /**
+     * Set the themeSettings object containing the theme configuration.
+     *
+     * @param {object} settings An object containing the theme configuration.
+     */
+    setThemeSettings(settings) {
+        this._themeSettings = settings;
+    };
+
+    /**
+     * Get the themeSettings object containing the theme configuration.
+     *
+     * @return {object} settings An object containing the theme configuration.
+     */
+    getThemeSettings() {
+        return this._themeSettings;
+    };
+
+    /**
+     * Reset decorator list.
+     */
+    resetDecorators() {
+        this._decorators = [];
+    };
+
+    /**
+     * Add a decorator to be applied at render time.
+     *
+     * @param {Function} decorator
+     */
+    addDecorator(decorator) {
+        this._decorators.push(decorator);
+    };
+
+    /**
+     * Setup content regions to be used by the `region` helper.
+     *
+     * @param {Object} Regions with widgets
+     */
+    setContent(regions) {
+        this._contentRegions = regions;
+    };
+
+    /**
+     * Get content regions.
+     *
+     * @param {Object} Regions with widgets
+     */
+    getContent() {
+        return this._contentRegions;
     };
 
     /**
@@ -158,33 +232,6 @@ class HandlebarsRenderer {
             return processed;
         };
     }
-
-    /**
-     * Add a decorator to be applied at render time.
-     *
-     * @param {Function} decorator
-     */
-    addDecorator(decorator) {
-        this._decorators.push(decorator);
-    };
-
-    /**
-     * Add content regions to be used by the `region` helper.
-     *
-     * @param {Object} Regions with widgets
-     */
-    addContent(regions) {
-        this._contentRegions = regions;
-    };
-
-    /**
-     * Get content regions.
-     *
-     * @param {Object} Regions with widgets
-     */
-    getContent() {
-        return this._contentRegions;
-    };
 
     /**
      * Render a template with the given context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/helpers/region.js
+++ b/spec/helpers/region.js
@@ -23,7 +23,7 @@ describe('Region Helper', () => {
         };
 
         renderer = buildRenderer();
-        renderer.addContent(context);
+        renderer.setContent(context);
 
         done();
     });

--- a/spec/index.js
+++ b/spec/index.js
@@ -64,26 +64,26 @@ describe('helper context', () => {
     });
 
     it('puts empty site settings into the helper context when not provided', done => {
-        expect(renderer.helperContext.siteSettings).to.equal({});
+        expect(renderer.helperContext.getSiteSettings()).to.equal({});
         done();
     });
 
     it('puts site settings into the helper context when provided', done => {
         siteSettings = { foo: 'bar' };
         renderer = new HandlebarsRenderer(siteSettings);
-        expect(renderer.helperContext.siteSettings).to.equal(siteSettings);
+        expect(renderer.helperContext.getSiteSettings()).to.equal(siteSettings);
         done();
     });
 
     it('puts empty theme settings into the helper context when not provided', done => {
-        expect(renderer.helperContext.themeSettings).to.equal({});
+        expect(renderer.helperContext.getThemeSettings()).to.equal({});
         done();
     });
 
     it('puts theme settings into the helper context when provided', done => {
         themeSettings = { foo: 'bar' };
         renderer = new HandlebarsRenderer({}, themeSettings);
-        expect(renderer.helperContext.themeSettings).to.equal(themeSettings);
+        expect(renderer.helperContext.getThemeSettings()).to.equal(themeSettings);
         done();
     });
 
@@ -96,7 +96,7 @@ describe('helper context', () => {
 
     it('puts page content accessor into the helper context', done => {
         const content = { foo: 'bar' };
-        renderer.addContent(content);
+        renderer.setContent(content);
         expect(renderer.helperContext.getContent()).to.equal(content);
         done();
     });


### PR DESCRIPTION
## What? Why?
* Change addContent() to setContent() for consistency with other setters.
* Add getter and setter for siteSettings and themeSettings, and change helper context
  to use a bound function for accessing these data to allow for deferred setting.
  Callers should no longer access siteSettings and themeSettings directly.

## How was it tested?
`npm test`

----

cc @bigcommerce/storefront-team
