### PR TITLE
STRF-4420: Fix scope of call to getSiteSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
-## 1.0.0
-- Initial extraction from stencil-paper
+## 3.0.1
+- Fix cdn and stylesheet helpers to pull latest siteSettings and themeSettings
+
+## 3.0.0
+- Change addContent() to setContent() for consistency with other setters.
+- Add getter and setter for siteSettings and themeSettings, and change helper context
+  to use a bound function for accessing these data to allow for deferred setting.
+  Callers should no longer access siteSettings and themeSettings directly.
 
 ## 2.0.0
 - Change error handling to throw custom errors instead of swallowing the error
@@ -9,8 +15,5 @@
   the error condition.
 - Remove logging interface since we don't use it anymore.
 
-## 3.0.0
-- Change addContent() to setContent() for consistency with other setters.
-- Add getter and setter for siteSettings and themeSettings, and change helper context
-  to use a bound function for accessing these data to allow for deferred setting.
-  Callers should no longer access siteSettings and themeSettings directly.
+## 1.0.0
+- Initial extraction from stencil-paper

--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -2,20 +2,20 @@
 
 // Return a function that can be used to translate paths to cdn paths
 module.exports = globals => {
-    const siteSettings = globals.getSiteSettings();
-    const themeSettings = globals.getThemeSettings();
-
-    const cdnUrl = siteSettings.cdn_url || '';
-    const versionId = siteSettings.theme_version_id;
-    const editSessionId = siteSettings.theme_session_id;
-    const cdnSettings = themeSettings.cdn;
-
     /**
      * Add CDN base url to the relative path
      * @param  {String} path     Relative path
      * @return {String}          Url cdn
      */
     return function(path) {
+        const siteSettings = globals.getSiteSettings();
+        const themeSettings = globals.getThemeSettings();
+
+        const cdnUrl = siteSettings.cdn_url || '';
+        const versionId = siteSettings.theme_version_id;
+        const editSessionId = siteSettings.theme_session_id;
+        const cdnSettings = themeSettings.cdn;
+
         const protocolMatch = /(.*!?:)/;
 
         if (path instanceof globals.handlebars.SafeString) {

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -4,11 +4,11 @@ const _ = require('lodash');
 const buildCDNHelper = require('./lib/cdnify');
 
 const factory = globals => {
-    const cdnify = buildCDNHelper(globals);
-    const siteSettings = globals.getSiteSettings();
-    const configId = siteSettings.theme_config_id;
-
     return function(assetPath) {
+        const cdnify = buildCDNHelper(globals);
+        const siteSettings = globals.getSiteSettings();
+        const configId = siteSettings.theme_config_id;
+
         const options = arguments[arguments.length - 1];
 
         // append the configId only if the asset path starts with assets/css/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/index.js
+++ b/spec/index.js
@@ -71,7 +71,15 @@ describe('helper context', () => {
     it('puts site settings into the helper context when provided', done => {
         siteSettings = { foo: 'bar' };
         renderer = new HandlebarsRenderer(siteSettings);
-        expect(renderer.helperContext.getSiteSettings()).to.equal(siteSettings);
+        expect(renderer.helperContext.getSiteSettings().foo).to.equal('bar');
+        done();
+    });
+
+    it('puts site settings into the helper context when provided after construction', done => {
+        siteSettings = { foo: 'bar' };
+        renderer = new HandlebarsRenderer();
+        renderer.setSiteSettings(siteSettings);
+        expect(renderer.helperContext.getSiteSettings().foo).to.equal('bar');
         done();
     });
 
@@ -83,7 +91,15 @@ describe('helper context', () => {
     it('puts theme settings into the helper context when provided', done => {
         themeSettings = { foo: 'bar' };
         renderer = new HandlebarsRenderer({}, themeSettings);
-        expect(renderer.helperContext.getThemeSettings()).to.equal(themeSettings);
+        expect(renderer.helperContext.getThemeSettings().foo).to.equal('bar');
+        done();
+    });
+
+    it('puts theme settings into the helper context when provided after construction', done => {
+        themeSettings = { foo: 'bar' };
+        renderer = new HandlebarsRenderer();
+        renderer.setThemeSettings(themeSettings);
+        expect(renderer.helperContext.getThemeSettings().foo).to.equal('bar');
         done();
     });
 


### PR DESCRIPTION
## What? Why?
In the `cdn` and `stylesheet` helpers, we were making the call to `getThemeSettings` and `getSiteSettings` at the wrong time, so not getting the latest value if they were updated after construction.

## How was it tested?
Unit tests added

----

cc @bigcommerce/storefront-team
