### PR TITLE
Add preload to fetch fonts & do a preconnect to gstatic

### DIFF
--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -47,7 +47,7 @@ function googleParser(fonts) {
         collection.push(family + ':' + weights.join(','));
     });
 
-    return '<link href="//fonts.googleapis.com/css?family=' + collection.join('|') + '" rel="stylesheet">';
+    return '<link href="//fonts.googleapis.com/css?family=' + collection.join('|') + '" rel="preload" as=“font” onload="this.onload=null;this.rel="stylesheet">';
 }
 
 const factory = globals => {
@@ -72,8 +72,10 @@ const factory = globals => {
                 }
             }
         });
-
+        if (googleFonts.length > 0) {
+        linkElements.push('<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>');
         linkElements.push(googleParser(googleFonts));
+        }
 
         return new globals.handlebars.SafeString(linkElements.join(''));
     };


### PR DESCRIPTION
## What? Why?
This PR does 2 things;
1. load fonts as preload
2. Connect to gstatic before hand so we don't waste time making the connection

## Issues
preload does not work with all browsers. But there is a way to do it detect it.
```
const preloadSupported = () => {
  const link = document.createElement('link');
  const relList = link.relList;
  if (!relList || !relList.supports)
    return false;
  return relList.supports('preload');
};
```
Will look into it later on how to incorporate it.

## How was it tested?
Working on it
----

cc @bigcommerce/storefront-team
