### PR TITLE
Include protocol in the Google Fonts URL

### DIFF
--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -52,7 +52,7 @@ const fontProviders = {
         },
 
         buildLink: function(fonts) {
-            return '<link href="//fonts.googleapis.com/css?family=' + fonts.join('|') + '" rel="stylesheet">';
+            return '<link href="https://fonts.googleapis.com/css?family=' + fonts.join('|') + '" rel="stylesheet">';
         },
 
         buildFontLoaderConfig: function(fonts) {

--- a/spec/helpers/getFontsCollection.js
+++ b/spec/helpers/getFontsCollection.js
@@ -22,7 +22,7 @@ describe('getFontsCollection', function () {
         runTestCases([
             {
                 input: '{{getFontsCollection}}',
-                output: '<link href="//fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700" rel="stylesheet">',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700" rel="stylesheet">',
             },
         ], done);
     });
@@ -38,7 +38,7 @@ describe('getFontsCollection', function () {
         runTestCases([
             {
                 input: '{{getFontsCollection}}',
-                output: '<link href="//fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">',
             },
         ], done);
     });


### PR DESCRIPTION
### What?

This simple change allows us to use `{{ getFontsCollection }}` in the AMP layout.

Calling `{{ getFontsCollection }}` will return
`<link href="https://fonts.googleapis.com/css?family=..........">` 

rather than 
`<link href="//fonts.googleapis.com/css?family=..........">`

### Why?

We spotted this issue in our first round of UAT for a new theme we are preparing.

Presently, including `{{ getFontsCollection }}` in `layout/amp.html` to keep branding consistent and bring in fonts used in the theme results in a validation error on the [Google AMP Test site](https://search.google.com/test/amp).

![image](https://user-images.githubusercontent.com/6369235/42126410-38339194-7c80-11e8-9246-18e2a7f72638.png)

Currently to bring in all theme fonts to the AMP templates without a validation error requires we use the following Handlebars:

`<link href="https://fonts.googleapis.com/css?family={{first (last (split theme_settings.body-font '_') 2)}}:{{last (last (split theme_settings.body-font '_') 2)}}|{{first (last (split theme_settings.headings-font '_') 2)}}:{{last (last (split theme_settings.headings-font '_') 2)}}|{{first (last (split theme_settings.logo-font '_') 2)}}:{{last (last (split theme_settings.logo-font '_') 2)}}" rel="stylesheet">`

With the current theme we are working on it gets more cluttered, as we have a secondary font family option too, so it looks like this:

`<link href="https://fonts.googleapis.com/css?family={{first (last (split theme_settings.body-font '_') 2)}}:{{last (last (split theme_settings.body-font '_') 2)}}|{{first (last (split theme_settings.secondary-font '_') 2)}}:{{last (last (split theme_settings.secondary-font '_') 2)}}|{{first (last (split theme_settings.headings-font '_') 2)}}:{{last (last (split theme_settings.headings-font '_') 2)}}|{{first (last (split theme_settings.logo-font '_') 2)}}:{{last (last (split theme_settings.logo-font '_') 2)}}" rel="stylesheet">`

This ends up with the possibility of requesting duplicate fonts like this: 

![image](https://user-images.githubusercontent.com/6369235/42126512-c24c00e0-7c81-11e8-8a71-c7447a28c105.png)

`<link href="https://fonts.googleapis.com/css?family=Montserrat:400|Noto+Serif:400,400i|Montserrat:700|Montserrat:700" rel="stylesheet">`

### Observations

- The previous version omits the protocol to prevent https:// sites giving a mixed content/insecure error
- http:// sites don't complain about mixed protocol requests so the new version won't flag an error
- https:// sites always require protocols to match, so rendering `https://` in the link href doesn't matter; it's what is expected

### Results

We tested this change in our local development environment. The screenshots above show the validation errors and results of the inelegant Handlebars workaround.

Below shows the results after the change:

![image](https://user-images.githubusercontent.com/6369235/42126524-1ed19816-7c82-11e8-8885-87f6f210a3e8.png)

![image](https://user-images.githubusercontent.com/6369235/42126532-3a517160-7c82-11e8-8c08-1225c9a5d6ee.png)

----

cc @bigcommerce/storefront-team
