### PR TITLE
added under if helpers comparison of number string

### DIFF
--- a/helpers/if.js
+++ b/helpers/if.js
@@ -67,6 +67,13 @@ const factory = globals => {
                 result = (lvalue >= rvalue);
                 break;
 
+            case 'gtnum':  
+                if ((typeof lvalue === 'string') && (typeof(rvalue) === 'string') && (!isNaN(lvalue)) && (!isNaN(rvalue))) {
+                    result = (parseInt(lvalue) > parseInt(rvalue));
+                    break;
+                } else {
+                    throw new Error("Handlerbars Helper if gtnum accepts ONLY valid number string");
+                }
             case 'typeof':
                 result = (typeof lvalue === rvalue);
                 break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/helpers/if.js
+++ b/spec/helpers/if.js
@@ -80,6 +80,9 @@ describe('if helper', () => {
         expect(renderString('{{#if product "typeof" "object"}}big{{/if}}', context))
             .to.be.equal('big');
 
+        expect(renderString('{{#if "2" "gtnum" "1"}}big{{/if}}', context))
+            .to.be.equal('big');
+
         expect(renderString('{{#if string "typeof" "string"}}big{{/if}}', context))
             .to.be.equal('big');
 
@@ -112,11 +115,62 @@ describe('if helper', () => {
         expect(renderString('{{#if num2 "<=" num1}}big{{/if}}', context))
             .to.be.equal('');
 
+        expect(renderString('{{#if "1" "gtnum" "2"}}big{{/if}}', context))
+            .to.be.equal('');
+
+        expect(renderString('{{#if "1" "gtnum" "1"}}big{{/if}}', context))
+            .to.be.equal('');
+
         expect(renderString('{{#if product "typeof" "string"}}big{{/if}}', context))
             .to.be.equal('');
 
         expect(renderString('{{#if string "typeof" "object"}}big{{/if}}', context))
             .to.be.equal('');
+
+        done();
+    });
+
+
+    it('should throw an exeption when non string value sent to gtnum', function (done) {
+        try {
+            renderString('{{#if num1 "gtnum" "2"}}big{{/if}}');
+        } catch(e) {
+            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+        }
+
+        try {
+            renderString('{{#if "2" "gtnum" num2}}big{{/if}}');
+        } catch(e) {
+            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+        }
+
+        try {
+            renderString('{{#if num1 "gtnum" num2}}big{{/if}}');
+        } catch(e) {
+            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+        }
+
+        done();
+    });
+
+    it('should throw an exeption when NaN value sent to gtnum', function (done) {
+        try {
+            renderString('{{#if "aaaa" "gtnum" "2"}}big{{/if}}');
+        } catch(e) {
+            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+        }
+
+        try {
+            renderString('{{#if "2" "gtnum" "bbbb"}}big{{/if}}');
+        } catch(e) {
+            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+        }
+
+        try {
+            renderString('{{#if "aaaa" "gtnum" "bbbb"}}big{{/if}}');
+        } catch(e) {
+            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+        }
 
         done();
     });


### PR DESCRIPTION
## What? Why?
Under the "if" helper we didn't have a case for number strings that convert string that are numbers and compare them.This pr will add "gtnum" which takes an input of string -> convert them to integers and check if left grater than right. 

## How was it tested?
specs and manually.

cc @bigcommerce/storefront-team
