### PR TITLE
STRF-5485: Promise based render and renderString

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
   - 6
   - 8
+  - 10
 script:
   - npm install
   - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.0.0
+- Change render and renderString to return Promises instead of synchronous results.
+
+## 3.0.3
+- Add support for gtnum in if helper.
+
+## 3.0.2
+- Add getFontLoaderConfig and resourceHints helpers.
+
 ## 3.0.1
 - Fix cdn and stylesheet helpers to pull latest siteSettings and themeSettings
 

--- a/helpers/if.js
+++ b/helpers/if.js
@@ -67,13 +67,14 @@ const factory = globals => {
                 result = (lvalue >= rvalue);
                 break;
 
-            case 'gtnum':  
-                if ((typeof lvalue === 'string') && (typeof(rvalue) === 'string') && (!isNaN(lvalue)) && (!isNaN(rvalue))) {
-                    result = (parseInt(lvalue) > parseInt(rvalue));
-                    break;
+            case 'gtnum':
+                if (typeof lvalue === 'string' && typeof(rvalue) === 'string' && !isNaN(lvalue) && !isNaN(rvalue)) {
+                    result = parseInt(lvalue) > parseInt(rvalue);
                 } else {
-                    throw new Error("Handlerbars Helper if gtnum accepts ONLY valid number string");
+                    throw new Error("if gtnum only accepts numbers (as strings)");
                 }
+                break;
+
             case 'typeof':
                 result = (typeof lvalue === rvalue);
                 break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-4-Clause",
   "scripts": {
     "linter": "eslint .",
-    "test": "npm run linter && lab -v -t 98 --ignore WebAssembly,_time,format,SharedArrayBuffer,Atomics spec",
+    "test": "npm run linter && lab -v -t 98 --ignore WebAssembly,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec"
   },
   "repository": {
@@ -35,5 +35,8 @@
     "eslint": "~4.10.0",
     "lab": "~13.0.4",
     "sinon": "~2.1.0"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }

--- a/spec/helpers/all.js
+++ b/spec/helpers/all.js
@@ -1,13 +1,11 @@
-const Code = require('code'),
-      Lab = require('lab'),
+const Lab = require('lab'),
       lab = exports.lab = Lab.script(),
       describe = lab.experiment,
-      expect = Code.expect,
       it = lab.it,
-      renderString = require('../spec-helpers').renderString;
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('all helper', function() {
-    var context = {
+    const context = {
         num1: 1,
         num2: 2,
         product: {a: 1, b: 2},
@@ -21,77 +19,101 @@ describe('all helper', function() {
         big: 'big'
     };
 
+    // Build a test runner that uses a default context
+    const runTestCases = testRunner({context});
+
     it('(with single argument) should behave like if helper', function(done) {
-        expect(renderString('{{#all 1}}{{big}}{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all 1}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all "x"}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all ""}}big{{/all}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#all 0}}big{{/all}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#all ""}}big{{else}}small{{/all}}', context))
-            .to.be.equal('small');
-
-        expect(renderString('{{#all 0}}big{{else}}small{{/all}}', context))
-            .to.be.equal('small');
-
-        expect(renderString('{{#all num2}}big{{else}}small{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all product}}big{{else}}small{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all itemArray}}big{{else}}small{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all string}}big{{else}}small{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all emptyObject}}big{{else}}small{{/all}}', context))
-            .to.be.equal('small');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#all 1}}{{big}}{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all 1}}big{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all "x"}}big{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all ""}}big{{/all}}',
+                output: '',
+            },
+            {
+                input: '{{#all 0}}big{{/all}}',
+                output: '',
+            },
+            {
+                input: '{{#all ""}}big{{else}}small{{/all}}',
+                output: 'small',
+            },
+            {
+                input: '{{#all 0}}big{{else}}small{{/all}}',
+                output: 'small',
+            },
+            {
+                input: '{{#all num2}}big{{else}}small{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all product}}big{{else}}small{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all itemArray}}big{{else}}small{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all string}}big{{else}}small{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all emptyObject}}big{{else}}small{{/all}}',
+                output: 'small',
+            },
+        ], done);
     });
 
     it('should render "big" if all conditions truthy', function(done) {
-
-        expect(renderString('{{#all "1" true}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all 1 "1"}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all "text" alwaysTrue}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all alwaysTrue product num1 num2}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all alwaysTrue itemArray string}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#all "1" true}}big{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all 1 "1"}}big{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all "text" alwaysTrue}}big{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all alwaysTrue product num1 num2}}big{{/all}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all alwaysTrue itemArray string}}big{{/all}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should render empty if any condition is falsy', function(done) {
-
-        expect(renderString('{{#all emptyString num1}}big{{/all}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#all true 0 emptyArray alwaysTrue}}big{{/all}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#all true "" alwaysTrue}}big{{/all}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#all emptyString num1}}big{{/all}}',
+                output: '',
+            },
+            {
+                input: '{{#all true 0 emptyArray alwaysTrue}}big{{/all}}',
+                output: '',
+            },
+            {
+                input: '{{#all true "" alwaysTrue}}big{{/all}}',
+                output: '',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/any.js
+++ b/spec/helpers/any.js
@@ -1,51 +1,57 @@
-const Code = require('code'),
-      Lab = require('lab'),
+const Lab = require('lab'),
       lab = exports.lab = Lab.script(),
       describe = lab.experiment,
-      expect = Code.expect,
       it = lab.it,
-      renderString = require('../spec-helpers').renderString;
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('any helper (with option hash)', function() {
-    var context = {
+    const context = {
         big: 'big',
         arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
     };
 
+    // Build a test runner that uses a default context
+    const runTestCases = testRunner({context});
+
     it('should return "big" with matching predicate ', function(done) {
-
-        expect(renderString('{{#any arrayWithObjs a=1}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#any arrayWithObjs a=2}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#any arrayWithObjs b=1}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#any arrayWithObjs a=1}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any arrayWithObjs a=2}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any arrayWithObjs b=1}}{{big}}{{/any}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should return nothing without matching predicate ', function(done) {
-
-        expect(renderString('{{#any arrayWithObjs b=2}}{{big}}{{/any}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#any arrayWithObjs c=1}}{{big}}{{/any}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#any arrayWithObjs num=2}}{{big}}{{/any}}', context))
-            .to.be.equal('');
-
-        done();
-
+        runTestCases([
+            {
+                input: '{{#any arrayWithObjs b=2}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any arrayWithObjs c=1}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any arrayWithObjs num=2}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
     });
 });
 
 
 describe('any helper (with multiple arguments)', function() {
     // DEPRECATED: Moved to #or helper
-    var context = {
+    const context = {
         num1: 1,
         num2: 2,
         product: {a: 1, b: 2},
@@ -59,33 +65,40 @@ describe('any helper (with multiple arguments)', function() {
         arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
     };
 
+    // Build a test runner that uses a default context
+    const runTestCases = testRunner({context});
+
     it('should return "big" if at least one arg valid', function(done) {
-
-        expect(renderString('{{#any arrayWithObjs string}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#any "something test" itemArray}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#any "this is before the other test"}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#any alwaysFalse emptyArray string}}{{big}}{{/any}}', context))
-            .to.be.equal('big');
-
-        done();
-
+        runTestCases([
+            {
+                input: '{{#any arrayWithObjs string}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any "something test" itemArray}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any "this is before the other test"}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any alwaysFalse emptyArray string}}{{big}}{{/any}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should return "" when no arguments are valid', function(done) {
-
-        expect(renderString('{{#any emptyArray emptyObject alwaysFalse}}{{big}}{{/any}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#any "" false}}{{big}}{{/any}}', context))
-            .to.be.equal('');
-
-        done();
-
+        runTestCases([
+            {
+                input: '{{#any emptyArray emptyObject alwaysFalse}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any "" false}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/block.js
+++ b/spec/helpers/block.js
@@ -17,10 +17,10 @@ describe('partial and block helpers', function () {
                 content: 'World',
             };
 
-        expect(render('template', context, {}, {}, templates))
-            .to.contain('<html><body><h1>Hello</h1><p>World</p></body>/<html>');
-
-        done();
+        render('template', context, {}, {}, templates).then(result => {
+            expect(result).to.contain('<html><body><h1>Hello</h1><p>World</p></body>/<html>');
+            done();
+        });
     });
 
     it('should not trigger an error if partial name is empty', function (done) {
@@ -29,9 +29,10 @@ describe('partial and block helpers', function () {
             layout: 'Hello{{#block "page"}}{{/block}}',
         };
 
-        expect(render('template', {}, {}, {}, templates)).to.be.equal('Hello');
-
-        done();
+        render('template', {}, {}, {}, templates).then(result => {
+            expect(result).to.be.equal('Hello');
+            done();
+        });
     });
 
     it('should not trigger an error if block name is empty', function (done) {
@@ -40,8 +41,9 @@ describe('partial and block helpers', function () {
             layout: 'Hello{{#block}}{{/block}}',
         };
 
-        expect(render('template', {}, {}, {}, templates)).to.be.equal('Hello');
-
-        done();
+        render('template', {}, {}, {}, templates).then(result => {
+            expect(result).to.be.equal('Hello');
+            done();
+        });
     });
 });

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -1,168 +1,212 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('cdn helper', function () {
-    var context = {};
-    var settings = {
+    const context = {};
+    const siteSettings = {
         cdn_url: 'https://cdn.bcapp/3dsf74g',
         theme_version_id: '123',
     };
-    var themeSettings = {
+    const themeSettings = {
         cdn: {
             customcdn1: 'https://bigcommerce.customcdn.net',
-            customcdn2: 'http://cdn.mystore.com'
+            customcdn2: 'http://cdn.mystore.com',
         }
     };
 
+    // Build a test runner that uses a default context
+    const runTestCases = testRunner({context, siteSettings, themeSettings});
+
     it('should render the css cdn url', function (done) {
-        expect(renderString('{{cdn "assets/css/style.css"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/css/style.css');
-
-        expect(renderString('{{cdn "/assets/css/style.css"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/css/style.css');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "assets/css/style.css"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.css',
+            },
+            {
+                input: '{{cdn "/assets/css/style.css"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.css',
+            },
+        ], done);
     });
 
     it('should render normal assets cdn url', function (done) {
-        expect(renderString('{{cdn "assets/js/app.js"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/js/app.js');
-
-        expect(renderString('{{cdn "assets/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "assets/js/app.js"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/js/app.js',
+            },
+            {
+                input: '{{cdn "assets/img/image.jpg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/image.jpg',
+            },
+        ], done);
     });
 
     it('should not use the cdn url', function (done) {
-        expect(renderString('{{cdn "assets/img/image.jpg"}}', context))
-            .to.be.equal('/assets/img/image.jpg');
-
-        expect(renderString('{{cdn "assets/img/image.jpg"}}', context))
-            .to.be.equal('/assets/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "assets/img/image.jpg"}}',
+                output: '/assets/img/image.jpg',
+                siteSettings: {},
+                themeSettings: {},
+            },
+            {
+                input: '{{cdn "assets/img/image.jpg"}}',
+                output: '/assets/img/image.jpg',
+                siteSettings: {},
+                themeSettings: {},
+            },
+        ], done);
     });
 
     it('should return the same value if it is a full url', function (done) {
-
-        expect(renderString('{{cdn "https://example.com/app.js"}}', context, settings, themeSettings))
-            .to.be.equal('https://example.com/app.js');
-
-        expect(renderString('{{cdn "http://example.com/app.js"}}', context, settings, themeSettings))
-            .to.be.equal('http://example.com/app.js');
-
-        expect(renderString('{{cdn "//example.com/app.js"}}', context, settings, themeSettings))
-            .to.be.equal('//example.com/app.js');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "https://example.com/app.js"}}',
+                output: 'https://example.com/app.js',
+            },
+            {
+                input: '{{cdn "http://example.com/app.js"}}',
+                output: 'http://example.com/app.js',
+            },
+            {
+                input: '{{cdn "//example.com/app.js"}}',
+                output: '//example.com/app.js',
+            },
+        ], done);
     });
 
     it('should return an empty string if no path is provided', function (done) {
-
-        expect(renderString('{{cdn ""}}', context, settings, themeSettings))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn ""}}',
+                output: '',
+            },
+        ], done);
     });
 
     it('should return a webDav asset if webdav protocol specified', function (done) {
-
-        expect(renderString('{{cdn "webdav:img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/content/img/image.jpg');
-
-        expect(renderString('{{cdn "webdav:/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/content/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "webdav:img/image.jpg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/content/img/image.jpg',
+            },
+            {
+                input: '{{cdn "webdav:/img/image.jpg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/content/img/image.jpg',
+            },
+        ], done);
     });
 
     it('should not return a webDav asset if webdav protocol is not correct', function (done) {
-
-        expect(renderString('{{cdn "webbav:img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('/img/image.jpg');
-
-        expect(renderString('{{cdn "webbav:/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "webbav:img/image.jpg"}}',
+                output: '/img/image.jpg',
+            },
+            {
+                input: '{{cdn "webbav:/img/image.jpg"}}',
+                output: '/img/image.jpg',
+            },
+        ], done);
     });
 
     it('should return a custom CDN asset if protocol is configured', function (done) {
-
-        expect(renderString('{{cdn "customcdn1:img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn1:/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn2:img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn2:/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "customcdn1:img/image.jpg"}}',
+                output: 'https://bigcommerce.customcdn.net/img/image.jpg',
+            },
+            {
+                input: '{{cdn "customcdn1:/img/image.jpg"}}',
+                output: 'https://bigcommerce.customcdn.net/img/image.jpg',
+            },
+            {
+                input: '{{cdn "customcdn2:img/image.jpg"}}',
+                output: 'http://cdn.mystore.com/img/image.jpg',
+            },
+            {
+                input: '{{cdn "customcdn2:/img/image.jpg"}}',
+                output: 'http://cdn.mystore.com/img/image.jpg',
+            },
+        ], done);
     });
 
     it('should return a custom CDN asset when using nested helper', function (done) {
-
-        expect(renderString('{{cdn (concat "customcdn1:" "img/image.jpg")}}', context, settings, themeSettings))
-            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
-
-        expect(renderString('{{cdn (concat "customcdn1:" "/img/image.jpg")}}', context, settings, themeSettings))
-            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
-
-        expect(renderString('{{cdn (concat "customcdn2:" "img/image.jpg")}}', context, settings, themeSettings))
-            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
-
-        expect(renderString('{{cdn (concat "customcdn2:" "/img/image.jpg")}}', context, settings, themeSettings))
-            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn (concat "customcdn1:" "img/image.jpg")}}',
+                output: 'https://bigcommerce.customcdn.net/img/image.jpg',
+            },
+            {
+                input: '{{cdn (concat "customcdn1:" "/img/image.jpg")}}',
+                output: 'https://bigcommerce.customcdn.net/img/image.jpg',
+            },
+            {
+                input: '{{cdn (concat "customcdn2:" "img/image.jpg")}}',
+                output: 'http://cdn.mystore.com/img/image.jpg',
+            },
+            {
+                input: '{{cdn (concat "customcdn2:" "/img/image.jpg")}}',
+                output: 'http://cdn.mystore.com/img/image.jpg',
+            },
+        ], done);
     });
 
     it('should return a local CDN asset if no cdn url is configured', function (done) {
-
-        expect(renderString('{{cdn "customcdn1:img/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('/assets/cdn/customcdn1/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn1:/img/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('/assets/cdn/customcdn1/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn2:img/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('/assets/cdn/customcdn2/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn2:/img/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('/assets/cdn/customcdn2/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "customcdn1:img/image.jpg"}}',
+                output: '/assets/cdn/customcdn1/img/image.jpg',
+                siteSettings: {},
+            },
+            {
+                input: '{{cdn "customcdn1:/img/image.jpg"}}',
+                output: '/assets/cdn/customcdn1/img/image.jpg',
+                siteSettings: {},
+            },
+            {
+                input: '{{cdn "customcdn2:img/image.jpg"}}',
+                output: '/assets/cdn/customcdn2/img/image.jpg',
+                siteSettings: {},
+            },
+            {
+                input: '{{cdn "customcdn2:/img/image.jpg"}}',
+                output: '/assets/cdn/customcdn2/img/image.jpg',
+                siteSettings: {},
+            },
+        ], done);
     });
 
     it('should not return a custom CDN asset if protocol is not configured', function (done) {
-
-        expect(renderString('{{cdn "customcdn1:img/image.jpg"}}', context, settings, {}))
-            .to.be.equal('/img/image.jpg');
-
-        expect(renderString('{{cdn "customcdn1:/img/image.jpg"}}', context, settings, {}))
-            .to.be.equal('/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "customcdn1:img/image.jpg"}}',
+                output: '/img/image.jpg',
+                themeSettings: {},
+            },
+            {
+                input: '{{cdn "customcdn1:/img/image.jpg"}}',
+                output: '/img/image.jpg',
+                themeSettings: {},
+            },
+        ], done);
     });
 
     it('should return basic asset URL if protocol is not correct', function (done) {
-
-        expect(renderString('{{cdn "randomProtocol::img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('/img/image.jpg');
-
-        expect(renderString('{{cdn "randomProtocol:/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('/img/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{cdn "randomProtocol::img/image.jpg"}}',
+                output: '/img/image.jpg',
+            },
+            {
+                input: '{{cdn "randomProtocol:/img/image.jpg"}}',
+                output: '/img/image.jpg',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/compare.js
+++ b/spec/helpers/compare.js
@@ -1,87 +1,107 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('compare helper', function() {
-    var context = {
+    const context = {
         num1: 1,
         num2: 2,
         product: {a: 1, b: 2},
         string: 'yolo'
     };
 
+    // Build a test runner that uses a default context
+    const runTestCases = testRunner({context});
+
     it('should render "big" if all compares match', function(done) {
-
-        expect(renderString('{{#compare "1" num1 operator="=="}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare 1 num1 operator="==="}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare 2 num1 operator="!=="}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare num2 num1 operator="!="}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare num2 num1 operator=">"}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare num1 num2 operator="<"}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare num2 num1 operator=">="}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare num1 num2 operator="<="}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare product "object" operator="typeof"}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#compare string "string" operator="typeof"}}big{{/compare}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#compare "1" num1 operator="=="}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare 1 num1 operator="==="}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare 2 num1 operator="!=="}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare num2 num1 operator="!="}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare num2 num1 operator=">"}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare num1 num2 operator="<"}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare num2 num1 operator=">="}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare num1 num2 operator="<="}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare product "object" operator="typeof"}}big{{/compare}}',
+                output: 'big',
+            },
+            {
+                input: '{{#compare string "string" operator="typeof"}}big{{/compare}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should render empty for all cases', function(done) {
-
-        expect(renderString('{{#compare "2" num1 operator="=="}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare 2 num1 operator="==="}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare 1 num1 operator="!=="}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare num2 2 operator="!="}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare num1 20 operator=">"}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare 4 num2 operator="<"}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare num1 40 operator=">="}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare num2 num1 operator="<="}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare product "string" operator="typeof"}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#compare string "object" operator="typeof"}}big{{/compare}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#compare "2" num1 operator="=="}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare 2 num1 operator="==="}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare 1 num1 operator="!=="}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare num2 2 operator="!="}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare num1 20 operator=">"}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare 4 num2 operator="<"}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare num1 40 operator=">="}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare num2 num1 operator="<="}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare product "string" operator="typeof"}}big{{/compare}}',
+                output: '',
+            },
+            {
+                input: '{{#compare string "object" operator="typeof"}}big{{/compare}}',
+                output: '',
+            },
+        ], done);
     });
-
 });

--- a/spec/helpers/concat.js
+++ b/spec/helpers/concat.js
@@ -1,19 +1,25 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('concat helper', function() {
+    const context = {
+        var1: 'hello',
+        var2: 'world',
+    };
+
+    // Build a test runner
+    const runTestCases = testRunner({context});
 
     it('should concatanate two strings', function(done) {
-
-        expect(renderString('{{concat var1 var2}}', {var1: 'hello', var2: 'world'}))
-            .to.be.equal('helloworld');
-
-        done();
+        runTestCases([
+            {
+                input: '{{concat var1 var2}}',
+                output: 'helloworld',
+            },
+        ], done);
     });
 });
 

--- a/spec/helpers/dynamicComponent.js
+++ b/spec/helpers/dynamicComponent.js
@@ -1,32 +1,34 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('dynamicComponent helper', function() {
-    var templates = {
-            'component/fields/one': '1{{animal}}',
-            'component/fields/two': '2{{animal}}',
-            'component/fields/three': '3{{animal}}',
-        },
-        context = {
-            fields: [
-                {partial: 'one', animal: 'dog'},
-                {partial: 'two', animal: 'cat'},
-                {partial: 'three', animal: 'mouse'},
-            ],
-            field: {partial: 'two', animal: 'elephant'}
-        };
+    const templates = {
+              'component/fields/one': '1{{animal}}',
+              'component/fields/two': '2{{animal}}',
+              'component/fields/three': '3{{animal}}',
+          },
+          context = {
+              fields: [
+                  {partial: 'one', animal: 'dog'},
+                  {partial: 'two', animal: 'cat'},
+                  {partial: 'three', animal: 'mouse'},
+              ],
+              field: {partial: 'two', animal: 'elephant'}
+          };
+
+    // Build a test runner
+    const runTestCases = testRunner({context, templates});
 
     it('should render all dynamic templates accordingly', function(done) {
-
-        expect(renderString('{{#each fields}}{{dynamicComponent "component/fields"}} {{/each}}', context, {}, {}, templates))
-            .to.be.equal('1dog 2cat 3mouse ');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#each fields}}{{dynamicComponent "component/fields"}} {{/each}}',
+                output: '1dog 2cat 3mouse ',
+            },
+        ], done);
     });
 });
 

--- a/spec/helpers/equals.js
+++ b/spec/helpers/equals.js
@@ -1,35 +1,40 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('equals helper', function() {
-    var context = {
+    const context = {
         value: 5
     };
 
+    // Build a test runner
+    const runTestCases = testRunner({context});
+
     it('should render yes if the value is equal to 5', function(done) {
-
-        expect(renderString('{{#equals 5 value}}yes{{/equals}}', context))
-            .to.be.equal('yes');
-
-        expect(renderString('{{#equals value 5}}yes{{/equals}}', context))
-            .to.be.equal('yes');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#equals 5 value}}yes{{/equals}}',
+                output: 'yes',
+            },
+            {
+                input: '{{#equals value 5}}yes{{/equals}}',
+                output: 'yes',
+            },
+        ], done);
     });
 
     it('should render empty string', function(done) {
-
-        expect(renderString('{{#equals 6 value}}yes{{/equals}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#equals value 6}}yes{{/equals}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#equals 6 value}}yes{{/equals}}',
+                output: '',
+            },
+            {
+                input: '{{#equals value 6}}yes{{/equals}}',
+                output: '',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/for.js
+++ b/spec/helpers/for.js
@@ -1,89 +1,110 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('for helper', function() {
+    const context = { name: 'Joe' };
 
-    var context = {name: 'Joe'};
+    // Build a test runner
+    const runTestCases = testRunner({context});
 
-    it('should itarate 10 times', function(done) {
-
-        expect(renderString('{{#for 10 this}}{{$index}}:{{name}} {{/for}}', context))
-            .to.contain('1:Joe 2:Joe 3:Joe 4:Joe 5:Joe 6:Joe 7:Joe 8:Joe 9:Joe 10:Joe');
-
-        expect(renderString('{{#for 1 10 this}}{{$index}}:{{name}} {{/for}}', context))
-            .to.contain('1:Joe 2:Joe 3:Joe 4:Joe 5:Joe 6:Joe 7:Joe 8:Joe 9:Joe 10:Joe');
-
-        expect(renderString('{{#for 0 9 this}}{{$index}}:{{name}} {{/for}}', context))
-            .to.contain('0:Joe 1:Joe 2:Joe 3:Joe 4:Joe 5:Joe 6:Joe 7:Joe 8:Joe 9:Joe');
-
-        expect(renderString('{{#for 1000 1010 this}}{{$index}}:{{name}} {{/for}}', context))
-            .to.contain('1000:Joe 1001:Joe 1002:Joe 1003:Joe 1004:Joe 1005:Joe 1006:Joe 1007:Joe 1008:Joe 1009:Joe');
-
-        done();
+    it('should iterate 10 times', function(done) {
+        runTestCases([
+            {
+                input: '{{#for 10 this}}{{$index}}:{{name}} {{/for}}',
+                output: '1:Joe 2:Joe 3:Joe 4:Joe 5:Joe 6:Joe 7:Joe 8:Joe 9:Joe 10:Joe ',
+            },
+            {
+                input: '{{#for 1 10 this}}{{$index}}:{{name}} {{/for}}',
+                output: '1:Joe 2:Joe 3:Joe 4:Joe 5:Joe 6:Joe 7:Joe 8:Joe 9:Joe 10:Joe ',
+            },
+            {
+                input: '{{#for 0 9 this}}{{$index}}:{{name}} {{/for}}',
+                output: '0:Joe 1:Joe 2:Joe 3:Joe 4:Joe 5:Joe 6:Joe 7:Joe 8:Joe 9:Joe ',
+            },
+            {
+                input: '{{#for 1000 1010 this}}{{$index}}:{{name}} {{/for}}',
+                output: '1000:Joe 1001:Joe 1002:Joe 1003:Joe 1004:Joe 1005:Joe 1006:Joe 1007:Joe 1008:Joe 1009:Joe 1010:Joe ',
+            },
+        ], done);
     });
 
-    it('should not itarate more than 100 times', function(done) {
-
-        expect(renderString('{{#for 0 99}}x{{/for}}', context).length)
-            .to.be.equal(100);
-
-        expect(renderString('{{#for 1 100}}x{{/for}}', context).length)
-            .to.be.equal(100);
-
-        expect(renderString('{{#for 0 3000 this}}.{{/for}}', context).length)
-            .to.be.equal(100);
-
-        expect(renderString('{{#for 2015 3000}}.{{/for}}', context).length)
-            .to.be.equal(100);
-
-        done();
+    it('should not iterate more than 100 times', function(done) {
+        const expected = '.'.repeat(100);
+        runTestCases([
+            {
+                input: '{{#for 0 99}}.{{/for}}',
+                output: expected,
+            },
+            {
+                input: '{{#for 1 100}}.{{/for}}',
+                output: expected,
+            },
+            {
+                input: '{{#for 0 3000 this}}.{{/for}}',
+                output: expected,
+            },
+            {
+                input: '{{#for 2015 3000}}.{{/for}}',
+                output: expected,
+            },
+        ], done);
     });
 
     it('should render w/o context', function(done) {
-
-        expect(renderString('{{#for 10}}{{$index}} {{/for}}', context))
-            .to.be.equal('1 2 3 4 5 6 7 8 9 10 ');
-
-        expect(renderString('{{#for 1 10}}{{$index}} {{/for}}', context))
-            .to.be.equal('1 2 3 4 5 6 7 8 9 10 ');
-
-        expect(renderString('{{#for 0 9}}{{$index}} {{/for}}', context))
-            .to.be.equal('0 1 2 3 4 5 6 7 8 9 ');
-
-        expect(renderString('{{#for 0 20}}.{{/for}}', context))
-            .to.be.equal('.....................');
-
-        expect(renderString('{{#for 0 99}}{{/for}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#for 10}}{{$index}} {{/for}}',
+                output: '1 2 3 4 5 6 7 8 9 10 ',
+            },
+            {
+                input: '{{#for 1 10}}{{$index}} {{/for}}',
+                output: '1 2 3 4 5 6 7 8 9 10 ',
+            },
+            {
+                input: '{{#for 0 9}}{{$index}} {{/for}}',
+                output: '0 1 2 3 4 5 6 7 8 9 ',
+            },
+            {
+                input: '{{#for 0 20}}.{{/for}}',
+                output: '.....................',
+            },
+            {
+                input: '{{#for 0 99}}{{/for}}',
+                output: '',
+            },
+        ], done);
     });
 
-
     it('should convert strings to integers and iterate 10 times', function(done) {
-        var context = {
+        const context = {
             start: '1',
             end: '10'
-        }
+        };
 
-        expect(renderString('{{#for start end}}{{$index}} {{/for}}', context))
-            .to.be.equal('1 2 3 4 5 6 7 8 9 10 ');
-        done();
+        runTestCases([
+            {
+                input: '{{#for start end}}{{$index}} {{/for}}',
+                output: '1 2 3 4 5 6 7 8 9 10 ',
+                context: context,
+            },
+        ], done);
     });
 
     it('should not iterate if "from" is less than "to"', function(done) {
-        var context = {
+        const context = {
             start: 10,
             end: 1
-        }
+        };
 
-        expect(renderString('{{#for start end}}{{$index}} {{/for}}', context))
-            .to.be.equal('');
-        done();
+        runTestCases([
+            {
+                input: '{{#for start end}}{{$index}} {{/for}}',
+                output: '',
+                context: context,
+            },
+        ], done);
     });
 });

--- a/spec/helpers/getFontLoaderConfig.js
+++ b/spec/helpers/getFontLoaderConfig.js
@@ -1,14 +1,12 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('getFontLoaderConfig', function () {
     it('should return the expected font config', function (done) {
-        var themeSettings = {
+        const themeSettings = {
             'test1-font': 'Google_Open+Sans',
             'test2-font': 'Google_Open+Sans_400italic',
             'test3-font': 'Google_Open+Sans_700',
@@ -20,16 +18,18 @@ describe('getFontLoaderConfig', function () {
             'random-property': 'not a font'
         };
 
-        const template = "{{getFontLoaderConfig}}";
         const expectedConfig = {
-          google: {
-            families: ['Open Sans:,400italic,700', 'Karla:700', 'Lora:400', 'Volkron:', 'Droid:400,700', 'Crimson Text:400,700']
-          }
+            google: {
+                families: ['Open Sans:,400italic,700', 'Karla:700', 'Lora:400', 'Volkron:', 'Droid:400,700', 'Crimson Text:400,700']
+            }
         };
 
-        expect(renderString(template, {}, {}, themeSettings))
-            .to.be.equal(JSON.stringify(expectedConfig));
-
-        done();
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontLoaderConfig}}',
+                output: JSON.stringify(expectedConfig),
+            },
+        ], done);
     });
 });

--- a/spec/helpers/getFontsCollection.js
+++ b/spec/helpers/getFontsCollection.js
@@ -1,14 +1,12 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('getFontsCollection', function () {
     it('should return the expected font link', function (done) {
-        var themeSettings = {
+        const themeSettings = {
             'test1-font': 'Google_Open+Sans',
             'test2-font': 'Google_Open+Sans_400italic',
             'test3-font': 'Google_Open+Sans_700',
@@ -20,25 +18,28 @@ describe('getFontsCollection', function () {
             'random-property': 'not a font'
         };
 
-        var template = "{{getFontsCollection}}";
-
-        expect(renderString(template, {}, {}, themeSettings))
-            .to.be.equal('<link href="//fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|' +
-            'Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700" rel="stylesheet">');
-        done();
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontsCollection}}',
+                output: '<link href="//fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700" rel="stylesheet">',
+            },
+        ], done);
     });
 
     it('should not crash if a malformed Google font is passed', function (done) {
-        var themeSettings = {
+        const themeSettings = {
             'test1-font': 'Google_Open+Sans',
             'test2-font': 'Google_',
             'test3-font': 'Google'
         };
 
-        var template = "{{getFontsCollection}}";
-
-        expect(renderString(template, {}, {}, themeSettings))
-            .to.be.equal('<link href="//fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">');
-        done();
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontsCollection}}',
+                output: '<link href="//fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/getImage.js
+++ b/spec/helpers/getImage.js
@@ -1,10 +1,8 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 const themeSettings = {
     logo_image: '600x300',
@@ -24,8 +22,8 @@ const themeSettings = {
 };
 
 describe('getImage helper', function() {
-    var urlData = 'https://cdn.example.com/path/to/{:size}/image.png';
-    var context = {
+    const urlData = 'https://cdn.example.com/path/to/{:size}/image.png';
+    const context = {
         image_url: 'http://example.com/image.png',
         not_an_image: null,
         image: {
@@ -34,74 +32,89 @@ describe('getImage helper', function() {
         logoPreset: 'logo',
     };
 
+    const runTestCases = testRunner({context, themeSettings});
+
     it('should return a url if a url is passed', function(done) {
-        expect(renderString('{{getImage "http://example.com/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('http://example.com/image.jpg');
-
-        expect(renderString('{{getImage "https://example.com/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('https://example.com/image.jpg');
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage "http://example.com/image.jpg"}}',
+                output: 'http://example.com/image.jpg',
+            },
+            {
+                input: '{{getImage "https://example.com/image.jpg"}}',
+                output: 'https://example.com/image.jpg',
+            },
+        ], done);
     });
 
     it('should return empty if image is invalid', function(done) {
-
-        expect(renderString('{{getImage not_existing_image}}', context, {}, themeSettings))
-            .to.be.equal('');
-
-        expect(renderString('{{getImage not_an_image}}', context, {}, themeSettings))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage not_existing_image}}',
+                output: '',
+            },
+            {
+                input: '{{getImage not_an_image}}',
+                output: '',
+            },
+        ], done);
     });
 
     it('should use the preset from _images', function(done) {
-
-        expect(renderString('{{getImage image "logo"}}', context, {}, themeSettings))
-            .to.be.equal(urlData.replace('{:size}', '250x100'));
-
-        expect(renderString('{{getImage image "gallery"}}', context, {}, themeSettings))
-            .to.be.equal(urlData.replace('{:size}', '300x300'));
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage image "logo"}}',
+                output: urlData.replace('{:size}', '250x100'),
+            },
+            {
+                input: '{{getImage image "gallery"}}',
+                output: urlData.replace('{:size}', '300x300'),
+            },
+        ], done);
     });
 
     it('should use the size from the theme_settings', function(done) {
-
-        expect(renderString('{{getImage image "logo_image"}}', context, {}, themeSettings))
-            .to.be.equal(urlData.replace('{:size}', '600x300'));
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage image "logo_image"}}',
+                output: urlData.replace('{:size}', '600x300'),
+            },
+        ], done);
     });
 
     it('should use the default image url if image is invalid', function(done) {
-
-        expect(renderString('{{getImage not_an_image "logo" "http://image"}}', context, {}, themeSettings))
-            .to.be.equal('http://image');
-
-        expect(renderString('{{getImage not_an_image "logo" image_url}}', context, {}, themeSettings))
-            .to.be.equal(context.image_url);
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage not_an_image "logo" "http://image"}}',
+                output: 'http://image',
+            },
+            {
+                input: '{{getImage not_an_image "logo" image_url}}',
+                output: context.image_url,
+            },
+        ], done);
     });
 
     it('should use original size if not default is passed', function(done) {
-
-        expect(renderString('{{getImage image "bad_preset"}}', context, {}, themeSettings))
-            .to.be.equal(urlData.replace('{:size}', 'original'));
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage image "bad_preset"}}',
+                output: urlData.replace('{:size}', 'original'),
+            },
+        ], done);
     });
 
 
     it('should default to max value (width & height) if value is not provided', function(done) {
-
-        expect(renderString('{{getImage image "missing_values"}}', context, {}, themeSettings))
-            .to.be.equal(urlData.replace('{:size}', '4096x4096'));
-
-        expect(renderString('{{getImage image "missing_width"}}', context, {}, themeSettings))
-            .to.be.equal(urlData.replace('{:size}', '4096x100'));
-
-        done();
+        runTestCases([
+            {
+                input: '{{getImage image "missing_values"}}',
+                output: urlData.replace('{:size}', '4096x4096'),
+            },
+            {
+                input: '{{getImage image "missing_width"}}',
+                output: urlData.replace('{:size}', '4096x100'),
+            },
+        ], done);
     });
 });

--- a/spec/helpers/getShortMonth.js
+++ b/spec/helpers/getShortMonth.js
@@ -1,28 +1,63 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('getShortMonth helper', function() {
 
+    const runTestCases = testRunner({});
+
     it('should render an object properly', function(done) {
-
-        expect(renderString('{{getShortMonth 1}}')) .to.be.equal('Jan');
-        expect(renderString('{{getShortMonth 2}}')) .to.be.equal('Feb');
-        expect(renderString('{{getShortMonth 3}}')) .to.be.equal('Mar');
-        expect(renderString('{{getShortMonth 4}}')) .to.be.equal('Apr');
-        expect(renderString('{{getShortMonth 5}}')) .to.be.equal('May');
-        expect(renderString('{{getShortMonth 6}}')) .to.be.equal('Jun');
-        expect(renderString('{{getShortMonth 7}}')) .to.be.equal('Jul');
-        expect(renderString('{{getShortMonth 8}}')) .to.be.equal('Aug');
-        expect(renderString('{{getShortMonth 9}}')) .to.be.equal('Sep');
-        expect(renderString('{{getShortMonth 10}}')) .to.be.equal('Oct');
-        expect(renderString('{{getShortMonth 11}}')) .to.be.equal('Nov');
-        expect(renderString('{{getShortMonth 12}}')) .to.be.equal('Dec');
-
-        done();
+        runTestCases([
+            {
+                input: '{{getShortMonth 1}}',
+                output: 'Jan',
+            },
+            {
+                input: '{{getShortMonth 2}}',
+                output: 'Feb',
+            },
+            {
+                input: '{{getShortMonth 3}}',
+                output: 'Mar',
+            },
+            {
+                input: '{{getShortMonth 4}}',
+                output: 'Apr',
+            },
+            {
+                input: '{{getShortMonth 5}}',
+                output: 'May',
+            },
+            {
+                input: '{{getShortMonth 6}}',
+                output: 'Jun',
+            },
+            {
+                input: '{{getShortMonth 7}}',
+                output: 'Jul',
+            },
+            {
+                input: '{{getShortMonth 8}}',
+                output: 'Aug',
+            },
+            {
+                input: '{{getShortMonth 9}}',
+                output: 'Sep',
+            },
+            {
+                input: '{{getShortMonth 10}}',
+                output: 'Oct',
+            },
+            {
+                input: '{{getShortMonth 11}}',
+                output: 'Nov',
+            },
+            {
+                input: '{{getShortMonth 12}}',
+                output: 'Dec',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/helperMissing.js
+++ b/spec/helpers/helperMissing.js
@@ -1,18 +1,16 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Code = require('code'),
+      Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      expect = Code.expect,
+      it = lab.it,
+      renderString = require('../spec-helpers').renderString;
 
 describe('helperMissing', function() {
-
     it('should return empty string if the helper is missing', function(done) {
-
-        expect(renderString('{{thisHelperDoesNotExist}}', {}))
-            .to.be.equal('');
-
-        done();
+        renderString('{{thisHelperDoesNotExist}}', {}).then(result => {
+            expect(result).to.be.equal('');
+            done();
+        });
     });
 });

--- a/spec/helpers/if.js
+++ b/spec/helpers/if.js
@@ -1,13 +1,13 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      specHelpers = require('../spec-helpers'),
+      testRunner = specHelpers.testRunner,
+      renderString = specHelpers.renderString;
 
 describe('if helper', () => {
-    var context = {
+    const context = {
         num1: 1,
         num2: 2,
         product: {a: 1, b: 2},
@@ -17,205 +17,236 @@ describe('if helper', () => {
         big: 'big'
     };
 
+    const runTestCases = testRunner({context});
+
     it('should have the same behavior as the original if helper', done => {
-        expect(renderString('{{#if 1}}{{big}}{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if 1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if "x"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if ""}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 0}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if ""}}big{{else}}small{{/if}}', context))
-            .to.be.equal('small');
-
-        expect(renderString('{{#if 0}}big{{else}}small{{/if}}', context))
-            .to.be.equal('small');
-
-        expect(renderString('{{#if num2}}big{{else}}small{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if product}}big{{else}}small{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if string}}big{{else}}small{{/if}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#if 1}}{{big}}{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if 1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if "x"}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if ""}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if 0}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if ""}}big{{else}}small{{/if}}',
+                output: 'small',
+            },
+            {
+                input: '{{#if 0}}big{{else}}small{{/if}}',
+                output: 'small',
+            },
+            {
+                input: '{{#if num2}}big{{else}}small{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if product}}big{{else}}small{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if string}}big{{else}}small{{/if}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should render "big" if all conditions match', done => {
-
-        expect(renderString('{{#if "1" "==" num1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if 1 "===" num1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if 2 "!==" num1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num2 "!=" num1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num2 ">" num1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num1 "<" num2}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num2 ">=" num1}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num1 "<=" num2}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if product "typeof" "object"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if "2" "gtnum" "1"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if string "typeof" "string"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#if "1" "==" num1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if 1 "===" num1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if 2 "!==" num1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if num2 "!=" num1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if num2 ">" num1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if num1 "<" num2}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if num2 ">=" num1}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if num1 "<=" num2}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if product "typeof" "object"}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if "2" "gtnum" "1"}}big{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#if string "typeof" "string"}}big{{/if}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should render empty for all cases', done => {
-
-        expect(renderString('{{#if "2" "==" num1}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 2 "===" num1}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 1 "!==" num1}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num2 "!=" 2}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num1 ">" 20}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 4 "<" num2}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num1 ">=" 40}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num2 "<=" num1}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if "1" "gtnum" "2"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if "1" "gtnum" "1"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if product "typeof" "string"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if string "typeof" "object"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#if "2" "==" num1}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if 2 "===" num1}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if 1 "!==" num1}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if num2 "!=" 2}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if num1 ">" 20}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if 4 "<" num2}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if num1 ">=" 40}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if num2 "<=" num1}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if "1" "gtnum" "2"}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if "1" "gtnum" "1"}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if product "typeof" "string"}}big{{/if}}',
+                output: '',
+            },
+            {
+                input: '{{#if string "typeof" "object"}}big{{/if}}',
+                output: '',
+            },
+        ], done);
     });
 
-
     it('should throw an exeption when non string value sent to gtnum', function (done) {
-        try {
-            renderString('{{#if num1 "gtnum" "2"}}big{{/if}}');
-        } catch(e) {
-            expect(e.message).to.not.equal('');
-        }
-
-        try {
-            renderString('{{#if "2" "gtnum" num2}}big{{/if}}');
-        } catch(e) {
-            expect(e.message).to.not.equal('');
-        }
-
-        try {
-            renderString('{{#if num1 "gtnum" num2}}big{{/if}}');
-        } catch(e) {
-            expect(e.message).to.not.equal('');
-        }
-
-        done();
+        renderString('{{#if num1 "gtnum" "2"}}big{{/if}}').catch(e => {
+            renderString('{{#if "2" "gtnum" num2}}big{{/if}}').catch(e => {
+                renderString('{{#if num1 "gtnum" num2}}big{{/if}}').catch(e => {
+                    done();
+                });
+            });
+        });
     });
 
     it('should throw an exeption when NaN value sent to gtnum', function (done) {
-        try {
-            renderString('{{#if "aaaa" "gtnum" "2"}}big{{/if}}');
-        } catch(e) {
-            expect(e.message).to.not.equal('');
-        }
-
-        try {
-            renderString('{{#if "2" "gtnum" "bbbb"}}big{{/if}}');
-        } catch(e) {
-            expect(e.message).to.not.equal('');
-        }
-
-        try {
-            renderString('{{#if "aaaa" "gtnum" "bbbb"}}big{{/if}}');
-        } catch(e) {
-            expect(e.message).to.not.equal('');
-        }
-
-        done();
+        renderString('{{#if "aaaa" "gtnum" "2"}}big{{/if}}').catch(e => {
+            renderString('{{#if "2" "gtnum" "bbbb"}}big{{/if}}').catch(e => {
+                renderString('{{#if "aaaa" "gtnum" "bbbb"}}big{{/if}}').catch(e => {
+                    done();
+                });
+            });
+        });
     });
 
 
     it('should render "big" if all ifs match', done => {
-
-        var context = {
+        const context = {
             num1: 1,
             num2: 2,
             product: {a: 1, b: 2},
             string: 'yolo'
         };
 
-        expect(renderString('{{#if "1" num1 operator="=="}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if 1 num1 operator="==="}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if 2 num1 operator="!=="}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num2 num1 operator="!="}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num2 num1 operator=">"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num1 num2 operator="<"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num2 num1 operator=">="}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if num1 num2 operator="<="}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if product "object" operator="typeof"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#if string "string" operator="typeof"}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#if "1" num1 operator="=="}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if 1 num1 operator="==="}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if 2 num1 operator="!=="}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if num2 num1 operator="!="}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if num2 num1 operator=">"}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if num1 num2 operator="<"}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if num2 num1 operator=">="}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if num1 num2 operator="<="}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if product "object" operator="typeof"}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+            {
+                input: '{{#if string "string" operator="typeof"}}big{{/if}}',
+                output: 'big',
+                context: context,
+            },
+        ], done);
     });
 
     it('should render empty for all cases', done => {
@@ -228,56 +259,86 @@ describe('if helper', () => {
             emptyObject: {}
         };
 
-        expect(renderString('{{#if emptyObject}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if emptyArray}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if emptyArray.length}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if "2" num1 operator="=="}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 2 num1 operator="==="}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 1 num1 operator="!=="}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num2 2 operator="!="}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num1 20 operator=">"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if 4 num2 operator="<"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num1 40 operator=">="}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if num2 num1 operator="<="}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if product "string" operator="typeof"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#if string "object" operator="typeof"}}big{{/if}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#if emptyObject}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if emptyArray}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if emptyArray.length}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if "2" num1 operator="=="}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if 2 num1 operator="==="}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if 1 num1 operator="!=="}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if num2 2 operator="!="}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if num1 20 operator=">"}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if 4 num2 operator="<"}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if num1 40 operator=">="}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if num2 num1 operator="<="}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if product "string" operator="typeof"}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+            {
+                input: '{{#if string "object" operator="typeof"}}big{{/if}}',
+                output: '',
+                context: context,
+            },
+        ], done);
     });
 
     it('should work as a non-block helper when used as a subexpression', done => {
-        expect(renderString('{{#if (if num1 "!==" num2)}}{{big}}{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all (if num1 "!==" num2) "1" true}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#if (if num1 "!==" num2)}}{{big}}{{/if}}',
+                output: 'big',
+            },
+            {
+                input: '{{#all (if num1 "!==" num2) "1" true}}big{{/all}}',
+                output: 'big',
+            },
+        ], done);
     });
 });
 
@@ -292,49 +353,65 @@ describe('unless helper', () => {
         emptyArray: [],
     };
 
+    const runTestCases = testRunner({context});
+
     it('should print hello', done => {
-        expect(renderString('{{#unless num1 "===" num2}}hello{{/unless}}', context))
-            .to.be.equal('hello');
-
-        expect(renderString('{{#unless alwaysFalse}}hello{{/unless}}', context))
-            .to.be.equal('hello');
-
-        expect(renderString('{{#unless does_not_exist}}hello{{/unless}}', context))
-            .to.be.equal('hello');
-
-        done();
+        runTestCases([
+              {
+                  input: '{{#unless num1 "===" num2}}hello{{/unless}}',
+                  output: 'hello',
+              },
+              {
+                  input: '{{#unless alwaysFalse}}hello{{/unless}}',
+                  output: 'hello',
+              },
+              {
+                  input: '{{#unless does_not_exist}}hello{{/unless}}',
+                  output: 'hello',
+              },
+        ], done);
     });
 
     it('should print empty', done => {
-        expect(renderString('{{#unless num1 "===" num1}}hello{{/unless}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#unless alwaysTrue}}hello{{/unless}}', context))
-            .to.be.equal('');
-
-        expect(renderString('{{#unless product}}hello{{/unless}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+              {
+                  input: '{{#unless num1 "===" num1}}hello{{/unless}}',
+                  output: '',
+              },
+              {
+                  input: '{{#unless alwaysTrue}}hello{{/unless}}',
+                  output: '',
+              },
+              {
+                  input: '{{#unless product}}hello{{/unless}}',
+                  output: '',
+              },
+        ], done);
     });
 
     it('should work with arrays', done => {
-        expect(renderString('{{#unless emptyArray}}foo{{else}}bar{{/unless}}', context))
-            .to.be.equal('foo');
-
-        expect(renderString('{{#unless notEmptyArray}}foo{{else}}bar{{/unless}}', context))
-            .to.be.equal('bar');
-
-        done();
+        runTestCases([
+              {
+                  input: '{{#unless emptyArray}}foo{{else}}bar{{/unless}}',
+                  output: 'foo',
+              },
+              {
+                  input: '{{#unless notEmptyArray}}foo{{else}}bar{{/unless}}',
+                  output: 'bar',
+              },
+        ], done);
     });
 
     it('should work as a non-block helper when used as a subexpression', done => {
-        expect(renderString('{{#if (unless num1 "===" num2)}}big{{/if}}', context))
-            .to.be.equal('big');
-
-        expect(renderString('{{#all (unless num1 "===" num2) "1" true}}big{{/all}}', context))
-            .to.be.equal('big');
-
-        done();
+        runTestCases([
+              {
+                  input: '{{#if (unless num1 "===" num2)}}big{{/if}}',
+                  output: 'big',
+              },
+              {
+                  input: '{{#all (unless num1 "===" num2) "1" true}}big{{/all}}',
+                  output: 'big',
+              },
+        ], done);
     });
 })

--- a/spec/helpers/if.js
+++ b/spec/helpers/if.js
@@ -135,19 +135,19 @@ describe('if helper', () => {
         try {
             renderString('{{#if num1 "gtnum" "2"}}big{{/if}}');
         } catch(e) {
-            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+            expect(e.message).to.not.equal('');
         }
 
         try {
             renderString('{{#if "2" "gtnum" num2}}big{{/if}}');
         } catch(e) {
-            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+            expect(e.message).to.not.equal('');
         }
 
         try {
             renderString('{{#if num1 "gtnum" num2}}big{{/if}}');
         } catch(e) {
-            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+            expect(e.message).to.not.equal('');
         }
 
         done();
@@ -157,19 +157,19 @@ describe('if helper', () => {
         try {
             renderString('{{#if "aaaa" "gtnum" "2"}}big{{/if}}');
         } catch(e) {
-            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+            expect(e.message).to.not.equal('');
         }
 
         try {
             renderString('{{#if "2" "gtnum" "bbbb"}}big{{/if}}');
         } catch(e) {
-            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+            expect(e.message).to.not.equal('');
         }
 
         try {
             renderString('{{#if "aaaa" "gtnum" "bbbb"}}big{{/if}}');
         } catch(e) {
-            expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
+            expect(e.message).to.not.equal('');
         }
 
         done();

--- a/spec/helpers/inject.js
+++ b/spec/helpers/inject.js
@@ -1,23 +1,23 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('inject helper', function() {
-    var context = {
+    const context = {
         value1: "Big",
         value2: "Commerce",
     };
 
+    const runTestCases = testRunner({context});
+
     it('should inject variables', function(done) {
-        var template = "{{inject 'data1' value1}}{{inject 'data2' value2}}{{jsContext}}";
-
-        expect(renderString(template, context))
-            .to.be.equal('"{\\"data1\\":\\"Big\\",\\"data2\\":\\"Commerce\\"}"');
-
-        done();
+        runTestCases([
+            {
+                input: "{{inject 'data1' value1}}{{inject 'data2' value2}}{{jsContext}}",
+                output: '"{\\"data1\\":\\"Big\\",\\"data2\\":\\"Commerce\\"}"',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/join.js
+++ b/spec/helpers/join.js
@@ -1,45 +1,53 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('join helper', function() {
-    var context = {
+    const context = {
         list: ['Mario', 'Chris', 'Mick', 'Hau', 'Cody']
     };
 
+    const runTestCases = testRunner({context});
+
     it('should print a list of names', function(done) {
-
-        expect(renderString('{{join list " "}}', context))
-            .to.be.equal('Mario Chris Mick Hau Cody');
-
-        expect(renderString('{{join list ", "}}', context))
-            .to.be.equal('Mario, Chris, Mick, Hau, Cody');
-
-        done();
+        runTestCases([
+            {
+                input: '{{join list " "}}',
+                output: 'Mario Chris Mick Hau Cody',
+            },
+            {
+                input: '{{join list ", "}}',
+                output: 'Mario, Chris, Mick, Hau, Cody',
+            },
+        ], done);
     });
 
     it('should print a list of names and limit to 3', function(done) {
-        expect(renderString('{{join list " " limit=3}}', context))
-            .to.be.equal('Mario Chris Mick');
-
-        done();
+        runTestCases([
+            {
+                input: '{{join list " " limit=3}}',
+                output: 'Mario Chris Mick',
+            },
+        ], done);
     });
 
     it('should print a list of names and use "and" for the last name', function(done) {
-        expect(renderString('{{join list ", " lastSeparator=" and "}}', context))
-            .to.be.equal('Mario, Chris, Mick, Hau and Cody');
-
-        done();
+        runTestCases([
+            {
+                input: '{{join list ", " lastSeparator=" and "}}',
+                output: 'Mario, Chris, Mick, Hau and Cody',
+            },
+        ], done);
     });
 
     it('should print a list of names and limit to 3 and use "and" for the last name', function(done) {
-        expect(renderString('{{join list ", " limit=3 lastSeparator=" and "}}', context))
-            .to.be.equal('Mario, Chris and Mick');
-
-        done();
+        runTestCases([
+            {
+                input: '{{join list ", " limit=3 lastSeparator=" and "}}',
+                output: 'Mario, Chris and Mick',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/json.js
+++ b/spec/helpers/json.js
@@ -1,21 +1,22 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('json helper', function() {
+    const context = {
+        object: { a: 1, b: "hello" }
+    };
+
+    const runTestCases = testRunner({context});
 
     it('should render object to json format', function(done) {
-        var context = {
-            object: {a: 1, b: "hello"}
-        };
-
-        expect(renderString('{{{json object}}}', context))
-            .to.contain('{"a":1,"b":"hello"}');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{json object}}}',
+                output: '{"a":1,"b":"hello"}',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/lang.js
+++ b/spec/helpers/lang.js
@@ -1,21 +1,17 @@
 'use strict';
 
-const Code = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const beforeEach = lab.beforeEach;
 const describe = lab.experiment;
-const expect = Code.expect;
 const it = lab.it;
 
-const buildRenderer = require('../spec-helpers').buildRenderer;
-
-function renderString(renderer, template, context) {
-    return renderer.renderString(template, context);
-}
+const specHelpers = require('../spec-helpers');
+const buildRenderer = specHelpers.buildRenderer;
+const testRunner = specHelpers.testRunner;
 
 describe('lang helper', () => {
-    let context, renderer;
+    let context, renderer, runTestCases;
 
     beforeEach(done => {
         context = {
@@ -28,21 +24,28 @@ describe('lang helper', () => {
             translate: (key, params) => `Powered By ${params.name}`,
         });
 
+        runTestCases = testRunner({renderer, context});
+
         done();
     });
 
     it('should translate the key with attributes', done => {
-        expect(renderString(renderer, '{{lang "powered_by" name=name}}', context))
-            .to.be.equal('Powered By BigCommerce');
-
-        done();
+        runTestCases([
+            {
+                input: '{{lang "powered_by" name=name}}',
+                output: 'Powered By BigCommerce',
+            },
+        ], done);
     });
 
     it('should return an empty string if translator is undefined', done => {
         renderer.setTranslator(null);
 
-        expect(renderString(renderer, '{{lang "powered_by" name=name}}', context)).to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{lang "powered_by" name=name}}',
+                output: '',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/langJson.js
+++ b/spec/helpers/langJson.js
@@ -1,21 +1,17 @@
 'use strict';
 
-const Code = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const beforeEach = lab.beforeEach;
 const describe = lab.experiment;
-const expect = Code.expect;
 const it = lab.it;
 
-const buildRenderer = require('../spec-helpers').buildRenderer;
-
-function renderString(renderer, template, context) {
-    return renderer.renderString(template, context);
-}
+const specHelpers = require('../spec-helpers');
+const buildRenderer = specHelpers.buildRenderer;
+const testRunner = specHelpers.testRunner;
 
 describe('langJson helper', () => {
-    let renderer;
+    let renderer, runTestCases;
 
     beforeEach(done => {
         renderer = buildRenderer();
@@ -24,20 +20,28 @@ describe('langJson helper', () => {
             getLanguage: () => ({ locale: 'en' }),
         });
 
+        runTestCases = testRunner({renderer});
+
         done();
     });
 
     it('should return translation as JSON string if translator is defined', done => {
-        expect(renderString(renderer, '{{{langJson}}}')).to.be.equal(JSON.stringify(renderer.getTranslator().getLanguage()));
-
-        done();
+        runTestCases([
+            {
+                input: '{{{langJson}}}',
+                output: JSON.stringify(renderer.getTranslator().getLanguage()),
+            },
+        ], done);
     });
 
     it('should return an empty object as JSON string if translator is not defined', done => {
         renderer.setTranslator(null);
 
-        expect(renderString(renderer, '{{{langJson}}}')).to.be.equal('{}');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{langJson}}}',
+                output: '{}',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/limit.js
+++ b/spec/helpers/limit.js
@@ -1,27 +1,29 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('limit helper', function() {
+    const runTestCases = testRunner({});
 
     it('should limit an array properly', function(done) {
-
-        expect(renderString('{{#each (limit var 4)}}{{this}} {{/each}}', {var: [1,2,3,4,5,6,7,8]}))
-            .to.be.equal('1 2 3 4 ');
-
-        done();
+        runTestCases([
+            {
+                input: '{{#each (limit var 4)}}{{this}} {{/each}}',
+                output: '1 2 3 4 ',
+                context: {var: [1,2,3,4,5,6,7,8]},
+            },
+        ], done);
     });
 
     it('should limit an string properly', function(done) {
-        var description = "This is longer than the chosen limit";
-
-        expect(renderString('{{limit var 10}}', {var: description}))
-            .to.be.equal('This is lo');
-
-        done();
+        runTestCases([
+            {
+                input: '{{limit var 10}}',
+                output: 'This is lo',
+                context: {var: "This is longer than the chosen limit"},
+            },
+        ], done);
     });
 });

--- a/spec/helpers/nl2br.js
+++ b/spec/helpers/nl2br.js
@@ -1,21 +1,22 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('nl2br helper', function() {
-    var context = {
+    const context = {
         text: "Hello\nmy\nname\nis\nJack"
     };
 
+    const runTestCases = testRunner({context});
+
     it('should convert new lines to <br> tags', function(done) {
-
-        expect(renderString('{{nl2br text}}', context))
-            .to.be.equal('Hello<br>\nmy<br>\nname<br>\nis<br>\nJack');
-
-        done();
+        runTestCases([
+            {
+                input: '{{nl2br text}}',
+                output: 'Hello<br>\nmy<br>\nname<br>\nis<br>\nJack',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/or.js
+++ b/spec/helpers/or.js
@@ -1,13 +1,11 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('or helper', function() {
-    var context = {
+    const context = {
         num1: 1,
         num2: 2,
         product: {a: 1, b: 2},
@@ -21,30 +19,40 @@ describe('or helper', function() {
         arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
     };
 
+    const runTestCases = testRunner({context});
+
     it('should return "big" if at least one arg valid', function(done) {
-        expect(renderString('{{#or arrayWithObjs string}}{{big}}{{/or}}', context))
-            .to.be.equal('big');
-      
-        expect(renderString('{{#or "something test" itemArray}}{{big}}{{/or}}', context))
-            .to.be.equal('big');
-      
-        expect(renderString('{{#or "this is before the other test"}}{{big}}{{/or}}', context))
-            .to.be.equal('big');
-      
-        expect(renderString('{{#or alwaysFalse emptyArray string}}{{big}}{{/or}}', context))
-            .to.be.equal('big');
-      
-        done();
+        runTestCases([
+            {
+                input: '{{#or arrayWithObjs string}}{{big}}{{/or}}',
+                output: 'big',
+            },
+            {
+                input: '{{#or "something test" itemArray}}{{big}}{{/or}}',
+                output: 'big',
+            },
+            {
+                input: '{{#or "this is before the other test"}}{{big}}{{/or}}',
+                output: 'big',
+            },
+            {
+                input: '{{#or alwaysFalse emptyArray string}}{{big}}{{/or}}',
+                output: 'big',
+            },
+        ], done);
     });
 
     it('should return "" when no arguments are valid', function(done) {
-        expect(renderString('{{#or emptyArray emptyObject alwaysFalse}}{{big}}{{/or}}', context))
-            .to.be.equal('');
-      
-        expect(renderString('{{#or "" false}}{{big}}{{/or}}', context))
-            .to.be.equal('');
-      
-        done();
+        runTestCases([
+            {
+                input: '{{#or emptyArray emptyObject alwaysFalse}}{{big}}{{/or}}',
+                output: '',
+            },
+            {
+                input: '{{#or "" false}}{{big}}{{/or}}',
+                output: '',
+            },
+        ], done);
     });
 });
 

--- a/spec/helpers/pluck.js
+++ b/spec/helpers/pluck.js
@@ -1,28 +1,29 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('pluck helper', function() {
-
-    var context = {
+    const context = {
         users: [
           { 'user': 'barney', 'age': 36 },
           { 'user': 'fred',   'age': 40 }
         ]
     };
 
+    const runTestCases = testRunner({context});
+
     it('should get the values from all elements in collection', function(done) {
-
-        expect(renderString('{{pluck users "age"}}', context))
-            .to.contain('36,40');
-
-        expect(renderString('{{#each (pluck users "user")}}hello {{this}} {{/each}}', context))
-            .to.contain('hello barney hello fred ');
-
-        done();
+        runTestCases([
+            {
+                input: '{{pluck users "age"}}',
+                output: '36,40',
+            },
+            {
+                input: '{{#each (pluck users "user")}}hello {{this}} {{/each}}',
+                output: 'hello barney hello fred ',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/pre.js
+++ b/spec/helpers/pre.js
@@ -1,26 +1,29 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('pre helper', function() {
+    const runTestCases = testRunner({});
 
     it('should render an object properly', function(done) {
-
-        expect(renderString('{{{pre var}}}', {var: {}}))
-            .to.be.equal('<pre>{}</pre>');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{pre var}}}',
+                output: '<pre>{}</pre>',
+                context: {var: {}},
+            },
+        ], done);
     });
 
     it('should scape html entities', function(done) {
-
-        expect(renderString('{{{pre var}}}', {var: "<div>&\"500\"</div>"}))
-            .to.be.equal('<pre>&quot;&lt;div&gt;&amp;\\&quot;500\\&quot;&lt;/div&gt;&quot;</pre>');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{pre var}}}',
+                output: '<pre>&quot;&lt;div&gt;&amp;\\&quot;500\\&quot;&lt;/div&gt;&quot;</pre>',
+                context: {var: "<div>&\"500\"</div>"},
+            },
+        ], done);
     });
 });

--- a/spec/helpers/region.js
+++ b/spec/helpers/region.js
@@ -1,21 +1,17 @@
 'use strict';
 
-const Code = require('code');
 const Lab = require('lab');
 const lab = exports.lab = Lab.script();
 const before = lab.before;
 const describe = lab.experiment;
-const expect = Code.expect;
 const it = lab.it;
 
-const buildRenderer = require('../spec-helpers').buildRenderer;
-
-function renderString(renderer, template, context) {
-    return renderer.renderString(template, context);
-}
+const specHelpers = require('../spec-helpers');
+const buildRenderer = specHelpers.buildRenderer;
+const testRunner = specHelpers.testRunner;
 
 describe('Region Helper', () => {
-    let context, renderer;
+    let context, renderer, runTestCases;
 
     before(done => {
         context = {
@@ -25,29 +21,36 @@ describe('Region Helper', () => {
         renderer = buildRenderer();
         renderer.setContent(context);
 
+        runTestCases = testRunner({context, renderer});
+
         done();
     });
 
     it('should return an empty string if no content service data (missing contentServiceContext) on page context', done => {
-        const noContent = buildRenderer();
-        expect(renderString(noContent, '{{region name="banner-bottom"}}', context))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: '{{region name="banner-bottom"}}',
+                output: '',
+                renderer: buildRenderer(),
+            },
+        ], done);
     });
 
     it('should return an empty container if no matching region on context object', done => {
-        expect(renderString(renderer, '{{region name="banner-bottom"}}', context))
-            .to.be.equal('<div data-content-region="banner-bottom"></div>');
-
-        done();
+        runTestCases([
+            {
+                input: '{{region name="banner-bottom"}}',
+                output: '<div data-content-region="banner-bottom"></div>',
+            },
+        ], done);
     });
 
     it('should return Hello World', done => {
-        expect(renderString(renderer, '{{region name="banner-top"}}', context))
-            .to.be.equal('<div data-content-region="banner-top">hello world</div>');
-
-        done();
+        runTestCases([
+            {
+                input: '{{region name="banner-top"}}',
+                output: '<div data-content-region="banner-top">hello world</div>',
+            },
+        ], done);
     });
-
 });

--- a/spec/helpers/replace.js
+++ b/spec/helpers/replace.js
@@ -1,10 +1,8 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('replace helper', function() {
     const templates = {
@@ -16,44 +14,58 @@ describe('replace helper', function() {
         price: '$49.99',
     };
 
+    const runTestCases = testRunner({context, templates});
+
     it('should replace all ocurrance of %%var%% with "day"', function(done) {
-
-        expect(renderString("{{#replace '%%var%%' content}}{{> template2}}{{/replace}}", context, {}, {}, templates))
-            .to.be.equal('Either you run the day or the  day runs you');
-
-        done();
+        runTestCases([
+            {
+                input: "{{#replace '%%var%%' content}}{{> template2}}{{/replace}}",
+                output: 'Either you run the day or the  day runs you',
+            },
+        ], done);
     });
 
     it('should handle undefined values', function(done) {
-        expect(renderString("{{#replace '%%var%%' content}}{{> template2}}{{/replace}}", {}, {}, {}, templates))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: "{{#replace '%%var%%' content}}{{> template2}}{{/replace}}",
+                output: '',
+                context: {},
+            },
+        ], done);
     });
 
     it('should replace $', function(done) {
-        expect(renderString("{{#replace '$' price}}{{/replace}}", context, {}, {}, templates))
-            .to.be.equal('49.99');
-
-        expect(renderString("{{#replace '$' '$10.00'}}{{/replace}}", context, {}, {}, templates))
-            .to.be.equal('10.00');
-
-        expect(renderString("{{#replace '$' '$10.00'}}USD {{/replace}}", context, {}, {}, templates))
-            .to.be.equal('USD 10.00');
-
-        done();
+        runTestCases([
+            {
+                input: "{{#replace '$' price}}{{/replace}}",
+                output: '49.99',
+            },
+            {
+                input: "{{#replace '$' '$10.00'}}{{/replace}}",
+                output: '10.00',
+            },
+            {
+                input: "{{#replace '$' '$10.00'}}USD {{/replace}}",
+                output: 'USD 10.00',
+            },
+        ], done);
     });
 
     it('should gracefully handle not strings', function(done) {
-        expect(renderString("{{#replace something price}}{{/replace}}", context, {}, {}, templates))
-            .to.be.equal('');
-
-        expect(renderString("{{#replace $ '$10.00'}}{{/replace}}", context, {}, {}, templates))
-            .to.be.equal('');
-
-        expect(renderString("{{#replace foo bar}}{{/replace}}", context, {}, {}, templates))
-            .to.be.equal('');
-
-        done();
+        runTestCases([
+            {
+                input: "{{#replace something price}}{{/replace}}",
+                output: '',
+            },
+            {
+                input: "{{#replace $ '$10.00'}}{{/replace}}",
+                output: '',
+            },
+            {
+                input: "{{#replace foo bar}}{{/replace}}",
+                output: '',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/resourceHints.js
+++ b/spec/helpers/resourceHints.js
@@ -1,14 +1,12 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('resourceHints', function () {
     it('should return the expected resource links', function (done) {
-        var themeSettings = {
+        const themeSettings = {
             'test1-font': 'Google_Open+Sans',
             'test2-font': 'Google_Open+Sans_400italic',
             'test3-font': 'Google_Open+Sans_700',
@@ -20,11 +18,13 @@ describe('resourceHints', function () {
             'random-property': 'not a font'
         };
 
-        const template = "{{resourceHints}}";
+        const runTestCases = testRunner({themeSettings});
 
-        expect(renderString(template, {}, {}, themeSettings))
-            .to.be.equal('<link rel="dns-prefetch preconnect" href="//ajax.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.gstatic.com" crossorigin>');
-
-        done();
+        runTestCases([
+            {
+                input: '{{resourceHints}}',
+                output: '<link rel="dns-prefetch preconnect" href="//ajax.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.gstatic.com" crossorigin>',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/snippets.js
+++ b/spec/helpers/snippets.js
@@ -1,18 +1,19 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('snippet helper', function() {
 
+    const runTestCases = testRunner({});
+
     it('should render a comment', function(done) {
-
-        expect(renderString('{{{snippet "header"}}}'))
-            .to.be.equal('<!-- snippet location header -->');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{snippet "header"}}}',
+                output: '<!-- snippet location header -->',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/stylesheet.js
+++ b/spec/helpers/stylesheet.js
@@ -1,49 +1,63 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('stylesheet helper', () => {
-    var settings = {
+    const siteSettings = {
         cdn_url: 'https://cdn.bcapp/hash',
         theme_version_id: '123',
         theme_config_id: 'xyz',
     };
-    it('should render a link tag with the cdn ulr and stencil-stylesheet data tag', done => {
-        expect(renderString('{{{stylesheet "assets/css/style.css"}}}', {}, settings))
-            .to.be.equal('<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/123/css/style-xyz.css" rel="stylesheet">');
 
-        done();
+    const runTestCases = testRunner({siteSettings});
+
+    it('should render a link tag with the cdn ulr and stencil-stylesheet data tag', done => {
+        runTestCases([
+            {
+                input: '{{{stylesheet "assets/css/style.css"}}}',
+                output: '<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/123/css/style-xyz.css" rel="stylesheet">',
+            },
+        ], done);
     });
 
     it('should render a link tag and all extra attributes with no cdn url', done => {
-        expect(renderString('{{{stylesheet "assets/css/style.css" fuck rel="something" class="myStyle"}}}'))
-            .to.be.equal('<link data-stencil-stylesheet href="/assets/css/style.css" rel="something" class="myStyle">');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{stylesheet "assets/css/style.css" blah rel="something" class="myStyle"}}}',
+                output: '<link data-stencil-stylesheet href="/assets/css/style.css" rel="something" class="myStyle">',
+                siteSettings: {},
+            },
+        ], done);
     });
 
     it('should render a link with empty href', done => {
-        expect(renderString('{{{stylesheet "" }}}'))
-            .to.be.equal('<link data-stencil-stylesheet href="" rel="stylesheet">');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{stylesheet "" }}}',
+                output: '<link data-stencil-stylesheet href="" rel="stylesheet">',
+            },
+        ], done);
     });
 
     it('should add configId to the filename', done => {
-        expect(renderString('{{{stylesheet "assets/css/style.css" }}}', {}, { theme_config_id: 'foo' }))
-            .to.be.equal('<link data-stencil-stylesheet href="/assets/css/style-foo.css" rel="stylesheet">');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{stylesheet "assets/css/style.css" }}}',
+                output: '<link data-stencil-stylesheet href="/assets/css/style-foo.css" rel="stylesheet">',
+                siteSettings: { theme_config_id: 'foo' },
+            },
+        ], done);
     });
 
     it('should not append configId if the file is not in assets/css/ directory', done => {
-        expect(renderString('{{{stylesheet "assets/lib/style.css" }}}', {}, { theme_config_id: 'foo' }))
-            .to.be.equal('<link data-stencil-stylesheet href="/assets/lib/style.css" rel="stylesheet">');
-
-        done();
+        runTestCases([
+            {
+                input: '{{{stylesheet "assets/lib/style.css" }}}',
+                output: '<link data-stencil-stylesheet href="/assets/lib/style.css" rel="stylesheet">',
+                siteSettings: { theme_config_id: 'foo' },
+            },
+        ], done);
     });
 });

--- a/spec/helpers/thirdParty.js
+++ b/spec/helpers/thirdParty.js
@@ -1,10 +1,8 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('third party handlebars-helpers', function() {
     const context = {
@@ -12,23 +10,29 @@ describe('third party handlebars-helpers', function() {
         options: { a: { b: { c: 'd' } } }
     };
 
+    const runTestCases = testRunner({context});
+
     describe('array helpers', function() {
 
         describe('after helper', function() {
             it('returns all the items in an array after the index', function(done) {
-                expect(renderString('{{after array 1}}', context))
-                    .to.be.equal('2,3,4,5');
-
-                done();
+                runTestCases([
+                    {
+                        input: '{{after array 1}}',
+                        output: '2,3,4,5',
+                    },
+                ], done);
             });
         });
 
         describe('first helper', function() {
             it('returns the first n items in an array', function(done) {
-                expect(renderString('{{first array 2}}', context))
-                    .to.be.equal('1,2');
-
-                done();
+                runTestCases([
+                    {
+                        input: '{{first array 2}}',
+                        output: '1,2',
+                    },
+                ], done);
             });
         });
 
@@ -38,10 +42,12 @@ describe('third party handlebars-helpers', function() {
 
         describe('length helper', function() {
             it('returns the length of the array', function(done) {
-                expect(renderString('{{length array}}', context))
-                    .to.be.equal('5');
-
-                done();
+                runTestCases([
+                    {
+                        input: '{{length array}}',
+                        output: '5',
+                    },
+                ], done);
             });
         });
 
@@ -51,17 +57,21 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains helper', function() {
             it('renders the contains block if it evaluates to true', function(done) {
-                expect(renderString(`{{#contains array 1}}This will be rendered.{{else}}This will not be rendered.{{/contains}}`, context))
-                    .to.be.equal('This will be rendered.');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{#contains array 1}}This will be rendered.{{else}}This will not be rendered.{{/contains}}`,
+                        output: 'This will be rendered.',
+                    },
+                ], done);
             });
 
             it('renders the else block if it evaluates to false', function(done) {
-                expect(renderString(`{{#contains array '1'}}This will not be rendered.{{else}}This will be rendered.{{/contains}}`, context))
-                    .to.be.equal('This will be rendered.');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{#contains array '1'}}This will not be rendered.{{else}}This will be rendered.{{/contains}}`,
+                        output: 'This will be rendered.',
+                    },
+                ], done);
             });
         });
 
@@ -71,11 +81,13 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains moment', function() {
             it('renders the date in the format specified', function(done) {
-                const now = new Date()
-                expect(renderString(`{{#moment "1 year ago" "YYYY"}}{{/moment}}`, context))
-                    .to.be.equal(`${now.getFullYear() - 1}`);
-
-                done();
+                const now = new Date();
+                runTestCases([
+                    {
+                        input: `{{#moment "1 year ago" "YYYY"}}{{/moment}}`,
+                        output: `${now.getFullYear() - 1}`,
+                    },
+                ], done);
             });
         });
 
@@ -85,16 +97,18 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains ellipsis', function() {
             it('truncates a string to the specified length and appends an ellipsis', function(done) {
-                expect(renderString(`{{ellipsis "<span>foo bar baz</span>" 7}}`, context))
-                    .to.be.equal('foo bar…');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{ellipsis "<span>foo bar baz</span>" 7}}`,
+                        output: 'foo bar…',
+                    },
+                ], done);
             });
         });
 
         describe('contains thumbnailImage', function() {
             it('creates a <figure> with a thumbnail linked to an image', function(done) {
-                const ctxt = {
+                const context = {
                     data: {
                         id: 'id',
                         alt: 'alt',
@@ -105,10 +119,14 @@ describe('third party handlebars-helpers', function() {
                         }
                     }
                 };
-                expect(renderString(`{{{thumbnailImage data}}}`, ctxt)).to.be
-                    .equal('<figure id=\"image-id\">\n<img alt=\"alt\" src=\"thumbnail.png\" width=\"32\" height=\"32\">\n</figure>');
 
-                done();
+                runTestCases([
+                    {
+                        input: `{{{thumbnailImage data}}}`,
+                        output: '<figure id=\"image-id\">\n<img alt=\"alt\" src=\"thumbnail.png\" width=\"32\" height=\"32\">\n</figure>',
+                        context: context,
+                    },
+                ], done);
             });
         });
 
@@ -118,10 +136,12 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains ordinalize', function() {
             it('returns an ordinalized number as a string', function(done) {
-                expect(renderString(`{{ordinalize 42}}`, context))
-                    .to.be.equal('42nd');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{ordinalize 42}}`,
+                        output: '42nd',
+                    },
+                ], done);
             });
         });
 
@@ -131,10 +151,12 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains markdown', function() {
             it('converts a string of markdown to HTML', function(done) {
-                expect(renderString(`{{#markdown}}# Foo{{/markdown}}`, context))
-                    .to.be.equal('<h1>Foo</h1>\n');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{#markdown}}# Foo{{/markdown}}`,
+                        output: '<h1>Foo</h1>\n',
+                    },
+                ], done);
             });
         });
 
@@ -144,10 +166,12 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains avg', function() {
             it('returns the average of the numbers in an array', function(done) {
-                expect(renderString(`{{avg array}}`, context))
-                    .to.be.equal('3');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{avg array}}`,
+                        output: '3',
+                    },
+                ], done);
             });
         });
 
@@ -157,10 +181,12 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains option', function() {
             it('returns the nested prop of this.options', function(done) {
-                expect(renderString(`{{option "a.b.c"}}`, context))
-                    .to.be.equal('d');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{option "a.b.c"}}`,
+                        output: 'd',
+                    },
+                ], done);
             });
         });
 
@@ -170,17 +196,21 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains isObject', function() {
             it('returns true if the value is an object', function(done) {
-                expect(renderString(`{{isObject options}}`, context))
-                    .to.be.equal('true');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{isObject options}}`,
+                        output: 'true',
+                    },
+                ], done);
             });
 
             it('returns false if the value is not an object', function(done) {
-                expect(renderString(`{{isObject "foo"}}`, context))
-                    .to.be.equal('false');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{isObject "foo"}}`,
+                        output: 'false',
+                    },
+                ], done);
             });
         });
 
@@ -190,10 +220,12 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains capitalize', function() {
             it('capitalizes the first word in a sentence', function(done) {
-                expect(renderString(`{{capitalize "foo bar baz"}}`, context))
-                    .to.be.equal('Foo bar baz');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{capitalize "foo bar baz"}}`,
+                        output: 'Foo bar baz',
+                    },
+                ], done);
             });
         });
 
@@ -203,13 +235,13 @@ describe('third party handlebars-helpers', function() {
 
         describe('contains stripQuerystring', function() {
             it('strips the query string from a given url', function(done) {
-                expect(renderString(`{{stripQuerystring 'http://www.example.com?foo=1&bar=2&baz=3'}}`, context))
-                    .to.be.equal('http://www.example.com');
-
-                done();
+                runTestCases([
+                    {
+                        input: `{{stripQuerystring 'http://www.example.com?foo=1&bar=2&baz=3'}}`,
+                        output: 'http://www.example.com',
+                    },
+                ], done);
             });
         });
-
     });
-
 });

--- a/spec/helpers/toLowerCase.js
+++ b/spec/helpers/toLowerCase.js
@@ -1,45 +1,50 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('toLowerCase helper', function() {
-
-    var context = {
+    const context = {
         string: "I Love PIZZA",
         number: 365,
         object: {},
         array: [1, 2, 3]
     };
 
+    const runTestCases = testRunner({context});
+
     it('should convert string to lower case', function(done) {
-
-        expect(renderString('{{toLowerCase string}}', context))
-            .to.contain('i love pizza');
-
-        expect(renderString('{{toLowerCase "HELLO"}}', context))
-            .to.contain('hello');
-
-        done();
+        runTestCases([
+            {
+                input: '{{toLowerCase string}}',
+                output: 'i love pizza',
+            },
+            {
+                input: '{{toLowerCase "HELLO"}}',
+                output: 'hello',
+            },
+        ], done);
     });
 
     it('should properly handle values other than strings', function(done) {
-        
-        expect(renderString('{{toLowerCase number}}', context))
-            .to.contain('365');
-
-        expect(renderString('{{toLowerCase 5}}', context))
-            .to.contain('5');
-
-        expect(renderString('{{toLowerCase object}}', context))
-            .to.contain('[object Object]');
-
-        expect(renderString('{{toLowerCase array}}', context))
-            .to.contain('1,2,3');
-
-        done();
+         runTestCases([
+            {
+                input: '{{toLowerCase number}}',
+                output: '365',
+            },
+            {
+                input: '{{toLowerCase 5}}',
+                output: '5',
+            },
+            {
+                input: '{{toLowerCase object}}',
+                output: '[object Object]',
+            },
+            {
+                input: '{{toLowerCase array}}',
+                output: '1,2,3',
+            },
+        ], done);
     });
 });

--- a/spec/helpers/truncate.js
+++ b/spec/helpers/truncate.js
@@ -1,14 +1,11 @@
-var Code = require('code'),
-    Lab = require('lab'),
-    lab = exports.lab = Lab.script(),
-    describe = lab.experiment,
-    expect = Code.expect,
-    it = lab.it,
-    renderString = require('../spec-helpers').renderString;
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
 
 describe('truncate helper', function() {
-
-    var context = {
+    const context = {
         chinese_string: '𠜎𠜱𠝹𠱓𠱸𠲖𠳏',
         number: 2,
         spanish_string: 'mañana',
@@ -16,43 +13,54 @@ describe('truncate helper', function() {
         unicode_string: 'She ❤️️ this',
     };
 
-    it('should return the entire string if length is longer than the input string', function(done) {
+    const runTestCases = testRunner({context});
 
-        expect(renderString('{{truncate string 15}}', context))
-            .to.be.equal('hello world');
-        done();
+    it('should return the entire string if length is longer than the input string', function(done) {
+        runTestCases([
+            {
+                input: '{{truncate string 15}}',
+                output: 'hello world',
+            },
+        ], done);
     });
 
     it('should return the first length number of characters', function(done) {
-
-        expect(renderString('{{truncate string 5}}', context))
-            .to.be.equal('hello');
-        done();
+        runTestCases([
+            {
+                input: '{{truncate string 5}}',
+                output: 'hello',
+            },
+        ], done);
     });
 
     it('should return the first argument, coerced to a string, if it is not a string', function(done) {
-
-        expect(renderString('{{truncate number 5}}', context))
-            .to.be.equal('2');
-        done();
+        runTestCases([
+            {
+                input: '{{truncate number 5}}',
+                output: '2',
+            },
+        ], done);
     });
 
     it('should handle non-English strings', function(done) {
-
-        expect(renderString('{{truncate spanish_string 3}}', context))
-            .to.be.equal('mañ');
-
-        expect(renderString('{{truncate chinese_string 3}}', context))
-            .to.be.equal('𠜎𠜱𠝹');
-
-        done();
+        runTestCases([
+            {
+                input: '{{truncate spanish_string 3}}',
+                output: 'mañ',
+            },
+            {
+                input: '{{truncate chinese_string 3}}',
+                output: '𠜎𠜱𠝹',
+            },
+        ], done);
     });
 
     it('should handle unicode strings', function(done) {
-
-        expect(renderString('{{truncate unicode_string 5}}', context))
-            .to.be.equal('She ❤️');
-
-        done();
+        runTestCases([
+            {
+                input: '{{truncate unicode_string 5}}',
+                output: 'She ❤️',
+            },
+        ], done);
     });
 });

--- a/spec/index.js
+++ b/spec/index.js
@@ -198,8 +198,10 @@ describe('addTemplates', () => {
     it('can render using registered partials', done => {
         const processor = renderer.getPreProcessor();
         renderer.addTemplates(processor(templates));
-        expect(renderer.render('baz', { bat: '123' })).to.equal('123');
-        done();
+        renderer.render('baz', { bat: '123' }).then(result => {
+            expect(result).to.equal('123');
+            done();
+        });
     });
 
     it('isTemplateLoaded tells you if a template has been loaded', done => {
@@ -217,8 +219,10 @@ describe('addTemplates', () => {
         const processor = renderer.getPreProcessor();
         renderer.addTemplates(processor(templates));
         renderer.addTemplates(processor(newTemplates));
-        expect(renderer.render('baz', { bat: '123' })).to.equal('123');
-        done();
+        renderer.render('baz', { bat: '123' }).then(result => {
+            expect(result).to.equal('123');
+            done();
+        });
     });
 });
 
@@ -248,13 +252,17 @@ describe('render', () => {
     });
 
     it('can render using registered partials', done => {
-        expect(renderer.render('foo', context)).to.equal('baz');
-        done();
+        renderer.render('foo', context).then(result => {
+            expect(result).to.equal('baz');
+            done();
+        });
     });
 
     it('renders without a context', done => {
-        expect(renderer.render('foo')).to.equal('');
-        done();
+        renderer.render('foo').then(result => {
+            expect(result).to.equal('');
+            done();
+        });
     });
 
     it('sets the locale in the context if a translator is supplied', done => {
@@ -262,48 +270,49 @@ describe('render', () => {
             getLocale: () => 'en',
         };
         renderer.setTranslator(translator);
-        expect(renderer.render('with_locale', context)).to.equal('en');
-        done();
+        renderer.render('with_locale', context).then(result => {
+            expect(result).to.equal('en');
+            done();
+        });
     });
 
     it('sets the template path in the context', done => {
-        expect(renderer.render('with_template', context)).to.equal('with_template');
-        done();
+        renderer.render('with_template', context).then(result => {
+            expect(result).to.equal('with_template');
+            done();
+        });
     });
 
     it('applies decorators', done => {
         renderer.addDecorator(output => {
             return `<wrap>${output}</wrap>`;
         });
-        expect(renderer.render('foo', context)).to.equal('<wrap>baz</wrap>');
-        done();
+        renderer.render('foo', context).then(result => {
+            expect(result).to.equal('<wrap>baz</wrap>');
+            done();
+        });
     });
 
     it('can use helpers', done => {
-        expect(renderer.render('capitalize_foo', context)).to.equal('Baz');
-        done();
+        renderer.render('capitalize_foo', context).then(result => {
+            expect(result).to.equal('Baz');
+            done();
+        });
     });
 
     it('throws TemplateNotFound if missing template', done => {
-        try {
-            renderer.render('nonexistent-template', context);
-        } catch(e) {
+        renderer.render('nonexistent-template', context).catch(e => {
             expect(e instanceof HandlebarsRenderer.errors.TemplateNotFoundError).to.be.true();
-        }
-
-        done();
+            done();
+        });
     });
 
     it('throws RenderError if given bad template', done => {
         renderer.addTemplates({'bad-template': '{{'});
-
-        try {
-            renderer.render('bad-template', context);
-        } catch(e) {
+        renderer.render('bad-template', context).catch(e => {
             expect(e instanceof HandlebarsRenderer.errors.RenderError).to.be.true();
-        }
-
-        done();
+            done();
+        });
     });
 
     it('throws DecoratorError if decorator fails', done => {
@@ -311,13 +320,10 @@ describe('render', () => {
             throw Error();
         });
 
-        try {
-            renderer.render('foo', context);
-        } catch(e) {
+        renderer.render('foo', context).catch(e => {
             expect(e instanceof HandlebarsRenderer.errors.DecoratorError).to.be.true();
-        }
-
-        done();
+            done();
+        });
     });
 });
 
@@ -339,38 +345,38 @@ describe('renderString', () => {
     });
 
     it('renders the given template with the given context', done => {
-        expect(renderer.renderString('<foo>{{bar}}</foo>', context)).to.equal('<foo>baz</foo>');
-        done();
+        renderer.renderString('<foo>{{bar}}</foo>', context).then(result => {
+            expect(result).to.equal('<foo>baz</foo>');
+            done();
+        });
     });
 
     it('can use helpers', done => {
-        expect(renderer.renderString('<foo>{{capitalize bar}}</foo>', context)).to.equal('<foo>Baz</foo>');
-        done();
+        renderer.renderString('<foo>{{capitalize bar}}</foo>', context).then(result => {
+            expect(result).to.equal('<foo>Baz</foo>');
+            done();
+        });
     });
 
     it('renders without a context', done => {
-        expect(renderer.renderString('foo')).to.equal('foo');
-        done();
+        renderer.renderString('foo', context).then(result => {
+            expect(result).to.equal('foo');
+            done();
+        });
     });
 
     it('throws CompileError if given a non-string template', done => {
-        try {
-            renderer.renderString(helpers.randomInt(), context);
-        } catch(e) {
+        renderer.renderString(helpers.randomInt(), context).catch(e => {
             expect(e instanceof HandlebarsRenderer.errors.CompileError).to.be.true();
-        }
-
-        done();
+            done();
+        });
     });
 
     it('throws RenderError if given malformed template', done => {
-        try {
-            renderer.renderString('{{', context);
-        } catch(e) {
+        renderer.renderString('{{', context).catch(e => {
             expect(e instanceof HandlebarsRenderer.errors.RenderError).to.be.true();
-        }
-
-        done();
+            done();
+        });
     });
 });
 


### PR DESCRIPTION
## What? Why?
* In preparation for moving rendering operations to a separate thread pool, update interface for render and renderString to return Promises rather than synchronous results. This is a breaking change, so we are bumping the version to 4.0.0.
* Refactor tests to make it easier to run a set of promise-based test cases without a lot of duplication
* Minor code cleanup of if helper
* Drop support for Node 4.x
* Add support for Node 10.x

## How was it tested?
* `npm test`
* Also in conjuction with new paper branch (PR coming shortly) and storefront-renderer (PR coming shortly)

----
cc @bigcommerce/storefront-team
