### PR TITLE
Handle case in cdn helper for img/icon-sprite.svg

### DIFF
--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -60,16 +60,20 @@ module.exports = globals => {
             return path;
         }
 
-        if (path[0] !== '/') {
-            path = '/' + path;
-        }
 
         if (!versionId) {
+            if (path[0] !== '/') {
+                path = '/' + path;
+            }
             return path;
         }
 
-        if (path.match(/^\/assets\//)) {
-            path = path.substr(8, path.length);
+        if (path[0] === '/') {
+            path = path.slice(1, path.length);
+        }
+
+        if (path.match(/^assets\//)) {
+            path = path.substr(7, path.length);
         }
 
         if (editSessionId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -209,4 +209,13 @@ describe('cdn helper', function () {
             },
         ], done);
     });
+
+    it('should avoid double slash in path', function (done) {
+        runTestCases([
+            {
+                input: '{{cdn "img/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/icon-sprite.svg',
+            }
+        ], done);
+    });
 });


### PR DESCRIPTION
## What? Why?
Currently we are generating cdn link for img/icon-sprite.svg with double slash (//img/icon-sprite.svg). This fix handle this case and avoid double slash.

## How was it tested?
Unitest and manually.

----

cc @bigcommerce/storefront-team
