### PR TITLE
MERC-4360: Always render regions

### DIFF
--- a/helpers/region.js
+++ b/helpers/region.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const _ = require('lodash');
-
 const factory = globals => {
     return function(params) {
         let regionId = params.hash.name;
         let contentRegions = globals.getContent();
 
-        if (_.keys(contentRegions).length === 0) {
+        if (!contentRegions) {
             return '';
         }
 

--- a/spec/helpers/region.js
+++ b/spec/helpers/region.js
@@ -26,11 +26,11 @@ describe('Region Helper', () => {
         done();
     });
 
-    it('should return an empty string if no content service data (missing contentServiceContext) on page context', done => {
+    it('should return an empty container if using empty content context', done => {
         runTestCases([
             {
                 input: '{{region name="banner-bottom"}}',
-                output: '',
+                output: '<div data-content-region="banner-bottom"></div>',
                 renderer: buildRenderer(),
             },
         ], done);


### PR DESCRIPTION
## What? Why?
Currently we are not rendering regions unless there is a widget in any region. This logic has changed between the old paper helper and the new paper-handlebars. This restores the original behavior.

----

cc @bigcommerce/storefront-team
