### PR TITLE
STRF-5711: Update resource hints

### DIFF
--- a/helpers/resourceHints.js
+++ b/helpers/resourceHints.js
@@ -5,9 +5,8 @@ const getFonts = require('./lib/fonts');
 
 const fontResources = {
     'Google': [
-        '//ajax.googleapis.com',
-        '//fonts.googleapis.com',
-        '//fonts.gstatic.com',
+        'https://fonts.googleapis.com',
+        'https://fonts.gstatic.com',
     ],
 };
 

--- a/spec/helpers/resourceHints.js
+++ b/spec/helpers/resourceHints.js
@@ -23,7 +23,7 @@ describe('resourceHints', function () {
         runTestCases([
             {
                 input: '{{resourceHints}}',
-                output: '<link rel="dns-prefetch preconnect" href="//ajax.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.gstatic.com" crossorigin>',
+                output: '<link rel="dns-prefetch preconnect" href="https://fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="https://fonts.gstatic.com" crossorigin>',
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?
* We now always connect to Google font hosts using https so update the resource hints to match
* Get rid of ajax.googleapis.com, which are unused in Cornerstone currently

## How was it tested?
`npm test`

----

cc @bigcommerce/storefront-team
