### PR TITLE
trimmed . and / in cdn helper for paths which are not full path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.4
+- Added trimming of all '.' and '/' from begginig of cdn path (not full paths)
+
 ## 4.0.3
 - Fix resourceHints to use https for font providers
 

--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -31,7 +31,13 @@ module.exports = globals => {
         }
 
         if (['.', '/'].includes(path[0])) {
-            path = path.replace(/^[^a-z\d]*/gi, '');
+            for (var i = 0; i < path.length; i++) {
+                if (['.', '/'].includes(path[0])) {
+                    path = path.substr(1);
+                } else {
+                    break;
+                }
+            }
         }
 
         if (protocolMatch.test(path)) {

--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -31,13 +31,7 @@ module.exports = globals => {
         }
 
         if (['.', '/'].includes(path[0])) {
-            for (var i = 0; i < path.length; i++) {
-                if (['.', '/'].includes(path[0])) {
-                    path = path.substr(1);
-                } else {
-                    break;
-                }
-            }
+            path = path.replace(/^[\.\/]+/, '');
         }
 
         if (protocolMatch.test(path)) {

--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -30,6 +30,10 @@ module.exports = globals => {
             return path;
         }
 
+        if (['.', '/'].includes(path[0])) {
+            path = path.replace(/^[^a-z\d]*/gi, '');
+        }
+
         if (protocolMatch.test(path)) {
             var match = path.match(protocolMatch);
             path = path.slice(match[0].length, path.length);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -110,6 +110,26 @@ describe('cdn helper', function () {
                 input: '{{cdn "../../../456IMG/icon-sprite.svg"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg',
             },
+            {
+                input: '{{cdn "../../../456IMG/icon-sprite.svg/"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg/',
+            },
+            {
+                input: '{{cdn "../../../456IMG/icon-sprite.svg."}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg.',
+            },
+            {
+                input: '{{cdn "../../../456IMG/icon-sprite.svg./"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg./',
+            },
+            {
+                input: '{{cdn "../../../456IMG/icon-sprite.svg../"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg../',
+            },
+            {
+                input: '{{cdn "../../../456IMG/icon-sprite.svg../../"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg../../',
+            },
         ], done);
     });
 

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -80,6 +80,39 @@ describe('cdn helper', function () {
         ], done);
     });
 
+    it('should delete any . and / from the begining of the path if this is not a full path', function (done) {
+        runTestCases([
+            {
+                input: '{{cdn "../img/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/icon-sprite.svg',
+            },
+            {
+                input: '{{cdn "./img/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/icon-sprite.svg',
+            },
+            {
+                input: '{{cdn "/img/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/icon-sprite.svg',
+            },
+            {
+                input: '{{cdn "../../img/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/icon-sprite.svg',
+            },
+            {
+                input: '{{cdn "../../../img/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/icon-sprite.svg',
+            },
+            {
+                input: '{{cdn "../../../IMG/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/IMG/icon-sprite.svg',
+            },
+            {
+                input: '{{cdn "../../../456IMG/icon-sprite.svg"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/456IMG/icon-sprite.svg',
+            },
+        ], done);
+    });
+
     it('should return an empty string if no path is provided', function (done) {
         runTestCases([
             {


### PR DESCRIPTION
## What? Why?
Currently, cdn helper is not handling relative path and not trim . or / from the begging of the path before creating cdn url. That cause paths such as ../example.com ,  ./example.com ,  /example.com,  ../../example.com, etc to generate wrong cdn url which leads to a wrong request by the browser (return 404)

## How was it tested?
Unitests

----

cc @bigcommerce/storefront-team
