### PR TITLE
STRF-6040 Fix regex performance to match precompiled templates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ class HandlebarsRenderer {
         // be a string representation of an object containing a `main`
         // function and a `compiler` array. We do this because the next
         // step is a potentially dangerous eval.
-        const re = /.*"compiler"\w*:\w*\[.*"main"\w*:\w*function/;
+        const re = /"compiler":\[.*\],"main":function/;
         if (!re.test(precompiled)) {
             // This is not a valid precompiled template, so this is
             // a raw template that can be registered directly.


### PR DESCRIPTION
## What? Why?
Fix regex performance to match precompiled templates.
`.*` at the beginning is forcing it to match all characters and for a big precompiled template file it takes over 10 sec.

## How was it tested?
The regex was matching every 

cc @bigcommerce/storefront-team @bigcommerce/platform-engineering 
