### PR TITLE
Specifically fail when encoding JSON for undefined

### DIFF
--- a/helpers/json.js
+++ b/helpers/json.js
@@ -2,6 +2,9 @@
 
 const factory = () => {
     return function(data) {
+        if(typeof data === 'undefined') {
+            throw new Error("Handlebars Helper 'json' does not allow value of 'undefined'");
+        }
         return JSON.stringify(data);
     };
 };

--- a/spec/helpers/json.js
+++ b/spec/helpers/json.js
@@ -2,11 +2,15 @@ const Lab = require('lab'),
       lab = exports.lab = Lab.script(),
       describe = lab.experiment,
       it = lab.it,
-      testRunner = require('../spec-helpers').testRunner;
+      expect = require('code').expect,
+      testRunner = require('../spec-helpers').testRunner,
+      buildRenderer = require('../spec-helpers').buildRenderer,
+      RenderError = require('../../index').errors.RenderError;
 
 describe('json helper', function() {
     const context = {
-        object: { a: 1, b: "hello" }
+        object: { a: 1, b: "hello" },
+        undef: undefined
     };
 
     const runTestCases = testRunner({context});
@@ -18,5 +22,19 @@ describe('json helper', function() {
                 output: '{"a":1,"b":"hello"}',
             },
         ], done);
+    });
+
+    it('should fail when provided undefined', function(done) {
+        const render = buildRenderer();
+
+        render.renderString('{{{json undef}}}', context).then((result) => {
+            return Promise.resolve(null);
+        }, (reason) => {
+            expect(reason).to.be.an.instanceof(RenderError);
+            return Promise.resolve(reason.message);
+        }).then((reason) => {
+            expect(reason).to.equal("Handlebars Helper 'json' does not allow value of 'undefined'");
+            done();
+        });
     });
 });


### PR DESCRIPTION
## What? Why?

The `json` helper should always produce syntactically correct JS.  Since the use case for the helper is usually `var something = {{{json something}}};`.  If a variable is trying to encode is undefined it would produce a difficult incorrect syntax like `var something = ;`.

So, instead, just fail!  This is probably a big deal and will impact things.

Related to https://github.com/bigcommerce/cornerstone/issues/1404 https://github.com/bigcommerce/cornerstone/issues/1425

## How was it tested?

Added test case.

----

Thank you for consideration.

cc @bigcommerce/storefront-team @jbruni
