### PR TITLE
STRF-6687 Change default behavior of {{getFontsCollection}} to use font-display: swap; for Google Fonts, allow configuration

### DIFF
--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -4,7 +4,9 @@ const getFonts = require('./lib/fonts');
 
 const factory = globals => {
     return function() {
-        return getFonts('linkElements', globals.getThemeSettings(), globals.handlebars);
+        const options = arguments.length === 1 ? arguments[arguments.length - 1] : null;
+        const fontDisplay = options && options.hash['font-display'] ? options.hash['font-display'] : null;
+        return getFonts('linkElements', globals.getThemeSettings(), globals.handlebars, {fontDisplay});
     };
 };
 

--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -51,8 +51,10 @@ const fontProviders = {
             return collection;
         },
 
-        buildLink: function(fonts) {
-            return '<link href="https://fonts.googleapis.com/css?family=' + fonts.join('|') + '" rel="stylesheet">';
+        buildLink: function(fonts, fontDisplay) {
+            const displayTypes = ['auto', 'block', 'swap', 'fallback', 'optional'];
+            fontDisplay = displayTypes.includes(fontDisplay) ? fontDisplay : 'swap';
+            return `<link href="https://fonts.googleapis.com/css?family=${fonts.join('|')}&display=${fontDisplay}" rel="stylesheet">`;
         },
 
         buildFontLoaderConfig: function(fonts) {
@@ -78,10 +80,11 @@ const fontProviders = {
  *   object that can be used to configure Web Font Loader.
  * @param {Object} themeSettings Object containing theme settings.
  * @param {Object} handlebars The handlebars instance.
+ * @param {Object} options an optional object for additional configuration details
  * @returns {Object.<string, Array>|string}
  */
-module.exports = function(format, themeSettings, handlebars) {
-    // Collect font strings from theme settings
+module.exports = function(format, themeSettings, handlebars, options) {
+    
     const collectedFonts = {};
     _.each(themeSettings, function(value, key) {
         if (!fontKeyFormat.test(key)) {
@@ -110,8 +113,9 @@ module.exports = function(format, themeSettings, handlebars) {
     // Format output based on requested format
     switch(format) {
     case 'linkElements':
+        
         const formattedFonts = _.mapValues(parsedFonts, function(value, key) {
-            return fontProviders[key].buildLink(value);
+            return fontProviders[key].buildLink(value, options.fontDisplay);
         });
         return new handlebars.SafeString(_.values(formattedFonts).join(''));
 

--- a/spec/helpers/getFontsCollection.js
+++ b/spec/helpers/getFontsCollection.js
@@ -5,7 +5,7 @@ const Lab = require('lab'),
       testRunner = require('../spec-helpers').testRunner;
 
 describe('getFontsCollection', function () {
-    it('should return the expected font link', function (done) {
+    it('should return a font link with fonts from theme settings and &display=swap when no font-display value is passed', function (done) {
         const themeSettings = {
             'test1-font': 'Google_Open+Sans',
             'test2-font': 'Google_Open+Sans_400italic',
@@ -22,12 +22,53 @@ describe('getFontsCollection', function () {
         runTestCases([
             {
                 input: '{{getFontsCollection}}',
-                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700" rel="stylesheet">',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700&display=swap" rel="stylesheet">',
             },
         ], done);
     });
+    it('should return a font link with fonts from theme settings and &display=swap when font-display value passed is invalid', function (done) {
+        const themeSettings = {
+            'test1-font': 'Google_Open+Sans',
+            'test2-font': 'Google_Open+Sans_400italic',
+            'test3-font': 'Google_Open+Sans_700',
+            'test4-font': 'Google_Karla_700',
+            'test5-font': 'Google_Lora_400_sans',
+            'test6-font': 'Google_Volkron',
+            'test7-font': 'Google_Droid_400,700',
+            'test8-font': 'Google_Crimson+Text_400,700_sans',
+            'random-property': 'not a font'
+        };
 
-    it('should not crash if a malformed Google font is passed', function (done) {
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontsCollection font-display="oreo"}}',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700&display=swap" rel="stylesheet">',
+            },
+        ], done);
+    });
+    it('should return a font link with fonts from theme settings and &display=${font-display} when valid font-display value is passed', function (done) {
+        const themeSettings = {
+            'test1-font': 'Google_Open+Sans',
+            'test2-font': 'Google_Open+Sans_400italic',
+            'test3-font': 'Google_Open+Sans_700',
+            'test4-font': 'Google_Karla_700',
+            'test5-font': 'Google_Lora_400_sans',
+            'test6-font': 'Google_Volkron',
+            'test7-font': 'Google_Droid_400,700',
+            'test8-font': 'Google_Crimson+Text_400,700_sans',
+            'random-property': 'not a font'
+        };
+
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontsCollection font-display="fallback"}}',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700&display=fallback" rel="stylesheet">',
+            },
+        ], done);
+    });
+    it('should not crash if a malformed Google font is passed when no font-display value is passed', function (done) {
         const themeSettings = {
             'test1-font': 'Google_Open+Sans',
             'test2-font': 'Google_',
@@ -38,7 +79,37 @@ describe('getFontsCollection', function () {
         runTestCases([
             {
                 input: '{{getFontsCollection}}',
-                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:&display=swap" rel="stylesheet">',
+            },
+        ], done);
+    });
+    it('should not crash if a malformed Google font is passed when valid font-display value is passed', function (done) {
+        const themeSettings = {
+            'test1-font': 'Google_Open+Sans',
+            'test2-font': 'Google_',
+            'test3-font': 'Google'
+        };
+
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontsCollection font-display="fallback"}}',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:&display=fallback" rel="stylesheet">',
+            },
+        ], done);
+    });
+    it('should not crash if a malformed Google font is passed when invalid font-display value is passed', function (done) {
+        const themeSettings = {
+            'test1-font': 'Google_Open+Sans',
+            'test2-font': 'Google_',
+            'test3-font': 'Google'
+        };
+
+        const runTestCases = testRunner({themeSettings});
+        runTestCases([
+            {
+                input: '{{getFontsCollection font-display="oreo"}}',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:&display=swap" rel="stylesheet">',
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?
Change default behavior of {{getFontsCollection}} to use font-display: swap; for Google Fonts, allow configuration
## How was it tested?
  
----
Unit tested can run test suite to check.
cc @bigcommerce/storefront-team
