### PR TITLE
feat(storefront): STRF-6753 Add "match" and "isRegex" helpers

### DIFF
--- a/helpers/thirdParty.js
+++ b/helpers/thirdParty.js
@@ -73,6 +73,10 @@ const whitelist = [
         include: ['markdown'],
     },
     {
+        name: 'match',
+        include: ['match', 'isMatch'],
+    },
+    {
         name: 'math',
         include: ['add', 'subtract', 'divide', 'multiply', 'floor', 'ceil', 'round', 'sum', 'avg'],
     },
@@ -109,6 +113,10 @@ const whitelist = [
             'JSONparse',
             'JSONstringify',
         ],
+    },
+    {
+        name: 'regex',
+        include: ['toRegex', 'test'],
     },
     {
         name: 'string',


### PR DESCRIPTION
## What? Why?
I've found a use case for these helpers while doing the testing described in https://github.com/bigcommerce/cornerstone/pull/1507 so I'd like to pull them in. This makes it a lot less verbose to use a subset of an array (in this case, the `theme_settings` array) without using `{{#each}}`

## How was it tested?
TBD

----

cc @bigcommerce/storefront-team
