### PR TITLE
Add getImageSrcset helper

### DIFF
--- a/helpers/getImageSrcset.js
+++ b/helpers/getImageSrcset.js
@@ -1,0 +1,63 @@
+'use strict';
+const utils = require('handlebars-utils');
+const SafeString = require('handlebars').SafeString;
+const common = require('./lib/common');
+
+const factory = () => {
+    return function(image, defaultImageUrl) {
+        // Regex to test size string is of the form 123x123 or 100w
+        const sizeRegex = /(^\d+w$)|(^(\d+?)x(\d+?)$)/;
+        // Regex to test to that srcset descriptor is of the form 1x 1.5x 2x OR 123w
+        const descriptorRegex = /(^\d+w$)|(^([0-9](\.[0-9]+)?)x)$/;
+
+        const options = arguments[arguments.length - 1];
+
+        if (utils.isUndefined(defaultImageUrl)) {
+            defaultImageUrl = '';
+        }
+
+        if (!utils.isObject(image) || !utils.isString (image.data)
+            || !common.isValidURL(image.data) || image.data.indexOf('{:size}') === -1) {
+            // return empty string if not a valid image object
+            defaultImageUrl = defaultImageUrl ? defaultImageUrl : '';
+            return utils.isString(image) ? image : defaultImageUrl;
+        }
+
+        let srcsets = {};
+
+        if (options.hash['use_default_sizes']) {
+            srcsets = {
+                '2560w': '2560w',
+                '1920w': '1920w',
+                '1280w': '1280w',
+                '960w': '960w',
+                '640w': '640w',
+                '320w': '320w',
+                '160w': '160w',
+                '80w': '80w',
+            };
+        } else {
+            srcsets = options.hash;
+            if (!utils.isObject(srcsets) || Object.keys(srcsets).some(descriptor => {
+                return !(descriptorRegex.test(descriptor) && sizeRegex.test(srcsets[descriptor]));
+            })) {
+                // return empty string if not valid srcset object
+                return ''
+            }
+        }
+
+        // If there's only one argument, return a `src` only (also works for `srcset`)
+        if (Object.keys(srcsets).length === 1) {
+            return new SafeString((image.data.replace('{:size}', srcsets[Object.keys(srcsets)[0]])));
+        }
+
+        return new SafeString(Object.keys(srcsets).reverse().map(descriptor => {
+            return ([image.data.replace('{:size}', srcsets[descriptor]), descriptor].join(' '));
+        }).join(', '));
+    };
+};
+
+module.exports = [{
+    name: 'getImageSrcset',
+    factory: factory,
+}];

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@bigcommerce/handlebars-v4": "bigcommerce/handlebars-v4#v4.0.14",
     "handlebars": "3.0.7",
     "handlebars-helpers": "0.8.4",
+    "handlebars-utils": "^1.0.6",
     "lodash": "^3.6.0",
     "stringz": "^0.1.1"
   },

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -30,6 +30,7 @@ describe('helper registration', () => {
             'getFontLoaderConfig',
             'getFontsCollection',
             'getImage',
+            'getImageSrcset',
             'helperMissing',
             'if',
             'inject',

--- a/spec/helpers/getImageSrcset.js
+++ b/spec/helpers/getImageSrcset.js
@@ -1,0 +1,123 @@
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
+
+describe('getImageSrcset helper', function() {
+    const urlData = 'https://cdn.example.com/path/to/{:size}/image.png?c=2';
+    const urlData_2_qs = 'https://cdn.example.com/path/to/{:size}/image.png?c=2&imbypass=on';
+    const context = {
+        image_url: 'http://example.com/image.png',
+        not_an_image: null,
+        image: {
+            data: urlData
+        },
+        image_with_2_qs: {
+            data: urlData_2_qs
+        },
+    };
+
+    const runTestCases = testRunner({context});
+
+    it('should return a srcset if a valid image and srcset sizes are passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset image 100w="100w" 200w="200w" 300w="300w" 1000w="1000w"}}',
+                output: 'https://cdn.example.com/path/to/100w/image.png?c=2 100w, https://cdn.example.com/path/to/200w/image.png?c=2 200w, https://cdn.example.com/path/to/300w/image.png?c=2 300w, https://cdn.example.com/path/to/1000w/image.png?c=2 1000w',
+            },
+            {
+                input: '{{getImageSrcset image_with_2_qs 100w="100w" 200w="200w" 300w="300w" 1000w="1000w"}}',
+                output: 'https://cdn.example.com/path/to/100w/image.png?c=2&imbypass=on 100w, https://cdn.example.com/path/to/200w/image.png?c=2&imbypass=on 200w, https://cdn.example.com/path/to/300w/image.png?c=2&imbypass=on 300w, https://cdn.example.com/path/to/1000w/image.png?c=2&imbypass=on 1000w',
+            },
+            {
+                input: '{{getImageSrcset image 1x="768x768" 2x="1536x1536"}}',
+                output: 'https://cdn.example.com/path/to/768x768/image.png?c=2 1x, https://cdn.example.com/path/to/1536x1536/image.png?c=2 2x',
+            },
+        ], done);
+    });
+
+    it('should return a srcset made of default sizes if requested', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset image use_default_sizes=true}}',
+                output: 'https://cdn.example.com/path/to/80w/image.png?c=2 80w, https://cdn.example.com/path/to/160w/image.png?c=2 160w, https://cdn.example.com/path/to/320w/image.png?c=2 320w, https://cdn.example.com/path/to/640w/image.png?c=2 640w, https://cdn.example.com/path/to/960w/image.png?c=2 960w, https://cdn.example.com/path/to/1280w/image.png?c=2 1280w, https://cdn.example.com/path/to/1920w/image.png?c=2 1920w, https://cdn.example.com/path/to/2560w/image.png?c=2 2560w',
+            },
+        ], done);
+    });
+
+    it('should return empty string if no parameters are passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset image}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return a srcset without a descriptor if a valid image and single srcset size is passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset image 100w="100w"}}',
+                output: 'https://cdn.example.com/path/to/100w/image.png?c=2',
+            },
+            {
+                input: '{{getImageSrcset image 1x="768x768"}}',
+                output: 'https://cdn.example.com/path/to/768x768/image.png?c=2',
+            },
+        ], done);
+    });
+
+
+    it('should return a url if a url is passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset "http://example.com/image.jpg"}}',
+                output: 'http://example.com/image.jpg',
+            },
+            {
+                input: '{{getImageSrcset "https://example.com/image.jpg"}}',
+                output: 'https://example.com/image.jpg',
+            },
+        ], done);
+    });
+
+    it('should return empty if srcset array is invalid', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset image 100="100w"}}',
+                output: '',
+            },
+            {
+                input: '{{getImageSrcset image abc="def"}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return empty if image is invalid', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset not_existing_image 100w="100w" 200w="200w"}}',
+                output: '',
+            },
+            {
+                input: '{{getImageSrcset not_an_image 100w="100w" 200w="200w"}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should use the default image url if image is invalid', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset not_an_image "http://image" 100w="100w" 200w="200w"}}',
+                output: 'http://image',
+            },
+            {
+                input: '{{getImageSrcset not_an_image image_url 100w="100w" 200w="200w"}}',
+                output: context.image_url,
+            },
+        ], done);
+    });
+});


### PR DESCRIPTION
## What? Why?
Adding a helper to make it easy to get a `srcset` string for an image.

The API is meant to feel familiar to a user of `getImage`.

Intended HTML usage:

`<img src="{{getImage image "default"}}" srcset="{{getImageSrcset image 100w="100w" 200w="200w" 300w="300w"}}" />`

Output would look like:

`https://cdn00.bigcommerce.com/s-abc123/images/stencil/100w/l/my-huge-image.original.jpg 100w, https://cdn00.bigcommerce.com/s-abc123/images/stencil/200w/l/my-huge-image.original.jpg 200w, https://cdn00.bigcommerce.com/s-abc123/images/stencil/300w/l/my-huge-image.original.jpg 300w`

Or perhaps:
```
`<img src="{{getImage image "default"}}" srcset="{{getImageSrcset image 1x="1000x1000" 2x="2000x2000"}}" />`
```

For this result:

`https://cdn00.bigcommerce.com/s-abc123/images/stencil/1000x1000/l/my-huge-image.original.jpg 1x, https://cdn00.bigcommerce.com/s-abc123/images/stencil/2000x2000/l/my-huge-image.original.jpg 2x`

If you supply no arguments, the helper will use a default set of sizes.

Contains handling for default image (just like `getImage`).

## How was it tested?
Unit tests added. I've verified that it works against a [custom branch of Cornerstone](https://github.com/bigcommerce/cornerstone/pull/1507).

cc @bigcommerce/storefront-team
