### PR TITLE
strf-6702 remove regex in font helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+- remove regex in fonts.js for better performance
 
 ## 4.0.6
 - Change default behavior of {{getFontsCollection}} to use font-display: swap for Google Fonts and allow configuration

--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const fontKeyFormat = new RegExp(/\w+(-\w*)*-font$/);
+
 const fontProviders = {
     'Google': {
         /**
@@ -87,7 +87,9 @@ module.exports = function(format, themeSettings, handlebars, options) {
     
     const collectedFonts = {};
     _.each(themeSettings, function(value, key) {
-        if (!fontKeyFormat.test(key)) {
+        //check that -font is on end of string but not start of string
+        const fontKeySuffix = '-font';
+        if (!key.endsWith(fontKeySuffix)) {
             return;
         }
 


### PR DESCRIPTION
## What? Why?
STRF-6702 Remove the usage of the fontKeyFormat regex in the font helpers.  Regex is expensive and this is an alternative to that.

## How was it tested?
----
Unit tests pass.
Ran an analysis on regular expression analyzer and found that regex was equivalent to that there needs to be a word character before the occurrence of '-font' and '-font' needs to be end of string.  Word characters in ecmascript are [^a-zA-Z_0-9].  
cc @bigcommerce/storefront-team
