### PR TITLE
STRF-6707 Don't use arguments in helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 - Remove regex in cdnify.js to improve performance
 - Remove regex in fonts.js for better performance
+- Refactor functions away from arguments pattern for better performance
 
 ## 4.0.6
 - Change default behavior of {{getFontsCollection}} to use font-display: swap for Google Fonts and allow configuration

--- a/helpers/all.js
+++ b/helpers/all.js
@@ -9,19 +9,12 @@ const _ = require('lodash');
  * {{#all items theme_settings.optionA theme_settings.optionB}} ... {{/all}}
  */
 const factory = () => {
-    return function() {
-        var args = [], opts, result;
-
-        // Translate arguments to array safely
-        for (var i = 0; i < arguments.length; i++) {
-            args.push(arguments[i]);
-        }
-
-        // Take the last argument (content) out of testing array
-        opts = args.pop();
+    return function(...args) {
+        // Take the last arg (which is a Handlebars options object) out of args array
+        const opts = args.pop();
 
         // Check if all the arguments are valid / truthy
-        result = _.all(args, function (arg) {
+        const result = _.all(args, function (arg) {
             if (_.isArray(arg)) {
                 return !!arg.length;
             }

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -9,20 +9,11 @@ const _ = require('lodash');
  * {{#any items selected=true}} ... {{/any}}
  */
 const factory = () => {
-    return function() {
-        var args = [],
-            opts,
-            predicate,
-            any;
-
-        // Translate arguments to array safely
-        for (var i = 0; i < arguments.length; i++) {
-            args.push(arguments[i]);
-        }
-
-        // Take the last argument (content) out of testing array
-        opts = args.pop();
-        predicate = opts.hash;
+    return function(...args) {
+        let any;
+        // Take the last arg (which is a Handlebars options object) out of args array
+        const opts = args.pop();
+        const predicate = opts.hash;
 
         if (!_.isEmpty(predicate)) {
             // With options hash, we check the contents of first argument

--- a/helpers/block.js
+++ b/helpers/block.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const factory = globals => {
-    return function(name) {
-        const options = arguments[arguments.length - 1];
-
+    return function(name, options) {
         /* Look for partial by name. */
+        options = options ? options : name;
         const partial = globals.handlebars.partials[name] || options.fn;
         return partial(this, { data: options.hash });
     };

--- a/helpers/compare.js
+++ b/helpers/compare.js
@@ -1,19 +1,14 @@
 'use strict';
 
 const factory = () => {
-    return function(lvalue, rvalue) {
-        const options = arguments[arguments.length - 1];
-        var operator;
-        var operators;
-        var result;
-
-        if (arguments.length < 3) {
-            throw new Error("Handlerbars Helper 'compare' needs 2 parameters");
+    return function(lvalue, rvalue, options) {
+        if (typeof options === 'undefined') {
+            throw new Error("Handlerbars Helper 'compare' needs 2 parameters and a block.");
         }
 
-        operator = options.hash.operator || "==";
+        const operator = options.hash.operator || "==";
 
-        operators = {
+        const operators = {
             '==': function (l, r) { return l == r; },
             '===': function (l, r) { return l === r; },
             '!=': function (l, r) { return l != r; },
@@ -32,7 +27,7 @@ const factory = () => {
             throw new Error("Handlerbars Helper 'compare' doesn't know the operator " + operator);
         }
 
-        result = operators[operator](lvalue, rvalue);
+        const result = operators[operator](lvalue, rvalue);
 
         if (result) {
             return options.fn(this);

--- a/helpers/contains.js
+++ b/helpers/contains.js
@@ -10,11 +10,8 @@ const _ = require('lodash');
  * {{#contains font_path "Roboto"}} ... {{/contains}}
  */
 const factory = () => {
-    return function() {
-        var args = Array.prototype.slice.call(arguments, 0, -1),
-            options = _.last(arguments),
-            contained = _.contains.apply(_, args);
-
+    return function(container, value, options) {
+        const contained = _.contains(container, value);
         // Yield block if true
         if (contained) {
             return options.fn(this);

--- a/helpers/for.js
+++ b/helpers/for.js
@@ -3,21 +3,22 @@
 const _ = require('lodash');
 
 const factory = () => {
-    return function(from, to, context) {
-        const options = arguments[arguments.length - 1];
+    return function(from, to, context, options) {
         const maxIterations = 100;
-        var output = '';
+        let output = '';
 
         function isOptions(obj) {
             return _.isObject(obj) && obj.fn;
         }
 
         if (isOptions(to)) {
+            options = to;
             context = {};
             to = from;
             from = 1;
 
         } else if (isOptions(context)) {
+            options = context;
             if (_.isObject(to)) {
                 context = to;
                 to = from;
@@ -36,11 +37,10 @@ const factory = () => {
             to = from + maxIterations - 1;
         }
 
-        for (var i = from; i <= to; i++) {
+        for (let i = from; i <= to; i++) {
             context.$index = i;
             output += options.fn(context);
         }
-
         return output;
     };
 };

--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -3,9 +3,8 @@
 const getFonts = require('./lib/fonts');
 
 const factory = globals => {
-    return function() {
-        const options = arguments.length === 1 ? arguments[arguments.length - 1] : null;
-        const fontDisplay = options && options.hash['font-display'] ? options.hash['font-display'] : null;
+    return function(options) {
+        const fontDisplay = options.hash['font-display'];
         return getFonts('linkElements', globals.getThemeSettings(), globals.handlebars, {fontDisplay});
     };
 };

--- a/helpers/if.js
+++ b/helpers/if.js
@@ -3,8 +3,7 @@
 const _ = require('lodash');
 
 const factory = globals => {
-    return function(lvalue, operator, rvalue) {
-        const options = arguments[arguments.length - 1];
+    return function(lvalue, operator, rvalue, options) {
         let result;
 
         function isOptions(obj) {
@@ -14,6 +13,7 @@ const factory = globals => {
         // Only parameter
         if (isOptions(operator)) {
             // If an array is passed as the only parameter
+            options = operator;
             if (_.isArray(lvalue)) {
                 result = !!lvalue.length;
             }
@@ -30,6 +30,7 @@ const factory = globals => {
             if (isOptions(rvalue)) {
                 // @TODO: this block is for backwards compatibility with 'compare' helper
                 // Remove after operator='==' is removed from stencil theme
+                options = rvalue;
                 rvalue = operator;
                 operator = options.hash.operator || "==";
             }

--- a/helpers/join.js
+++ b/helpers/join.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const factory = () => {
-    return function(array, separator) {
-        const options = arguments[arguments.length - 1];
-        var config = options.hash || {};
+    return function(array, separator, options) {
+        const config = options.hash || {};
 
         array = array.slice();
 
@@ -14,8 +13,8 @@ const factory = () => {
 
         // Use lastSeparator between last and second last item, if provided
         if (config.lastSeparator) {
-            var truncatedArray = array.slice(0, -1),
-                lastItem = array.slice(-1);
+            const truncatedArray = array.slice(0, -1);
+            const lastItem = array.slice(-1);
 
             return truncatedArray.join(separator) + config.lastSeparator + lastItem;
         }

--- a/helpers/lang.js
+++ b/helpers/lang.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const factory = globals => {
-    return function(translationKey) {
-        const options = arguments[arguments.length - 1];
+    return function(translationKey, options) {
         const translator = globals.getTranslator();
         return translator ? translator.translate(translationKey, options.hash) : '';
     };

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -9,21 +9,12 @@ const _ = require('lodash');
  * {{#or 1 0 0 0 0 0}} ... {{/or}}
  */
 const factory = () => {
-    return function() {
-        var args = [],
-            opts,
-            any;
-
-        // Translate arguments to array safely
-        for (var i = 0; i < arguments.length; i++) {
-            args.push(arguments[i]);
-        }
-
-        // Take the last argument (content) out of testing array
-        opts = args.pop();
+    return function(...args) {
+        // Take the last arg (which is a Handlebars options object) out of args array
+        const opts = args.pop();
 
         // Without options hash, we check all the arguments
-        any = _.any(args, function (arg) {
+        const any = _.any(args, function (arg) {
             if (_.isArray(arg)) {
                 return !!arg.length;
             }

--- a/helpers/partial.js
+++ b/helpers/partial.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const factory = globals => {
-    return function(name) {
-        const options = arguments[arguments.length - 1];
+    return function(name, options) {
+        options = options ? options : name;
         globals.handlebars.registerPartial(name, options.fn);
     };
 };

--- a/helpers/replace.js
+++ b/helpers/replace.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const factory = () => {
-    return function(needle, haystack) {
-        const options = arguments[arguments.length - 1];
-
+    return function(needle, haystack, options) {
         if (typeof needle !== 'string') {
             return options.inverse(this);
         }

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -4,12 +4,10 @@ const _ = require('lodash');
 const buildCDNHelper = require('./lib/cdnify');
 
 const factory = globals => {
-    return function(assetPath) {
+    return function(assetPath, options) {
         const cdnify = buildCDNHelper(globals);
         const siteSettings = globals.getSiteSettings();
         const configId = siteSettings.theme_config_id;
-
-        const options = arguments[arguments.length - 1];
 
         // append the configId only if the asset path starts with assets/css/
         const path = configId && assetPath.match(/^\/?assets\/css\//)

--- a/helpers/unless.js
+++ b/helpers/unless.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const factory = globals => {
-    return function() {
-        const options = arguments[arguments.length - 1];
-        arguments[arguments.length - 1] = Object.assign({}, options, {
+    return function(...args) {
+        const options = args[args.length - 1];
+        args[args.length - 1] = Object.assign({}, options, {
             fn: options.inverse || (() => false),
             inverse: options.fn || (() => true),
             hash: options.hash
         });
 
-        return globals.handlebars.helpers['if'].apply(this, arguments);
+        return globals.handlebars.helpers['if'].apply(this, args);
     };
 };
 

--- a/spec/helpers/block.js
+++ b/spec/helpers/block.js
@@ -37,7 +37,7 @@ describe('partial and block helpers', function () {
 
     it('should not trigger an error if block name is empty', function (done) {
         var templates = {
-            template: '{{#partial "page" "2134"}}World{{/partial}}{{> layout}}',
+            template: '{{#partial "page"}}World{{/partial}}{{> layout}}',
             layout: 'Hello{{#block}}{{/block}}',
         };
 

--- a/spec/helpers/stylesheet.js
+++ b/spec/helpers/stylesheet.js
@@ -25,7 +25,7 @@ describe('stylesheet helper', () => {
     it('should render a link tag and all extra attributes with no cdn url', done => {
         runTestCases([
             {
-                input: '{{{stylesheet "assets/css/style.css" blah rel="something" class="myStyle"}}}',
+                input: '{{{stylesheet "assets/css/style.css" rel="something" class="myStyle"}}}',
                 output: '<link data-stencil-stylesheet href="/assets/css/style.css" rel="something" class="myStyle">',
                 siteSettings: {},
             },


### PR DESCRIPTION
## What? Why?
STRF 6707 Don't use arguments in helpers.  Move away from arguments pattern so that performance may be improved.

## How was it tested?

----
Added unit test for for helper fix and current unit tests don't break.
cc @bigcommerce/storefront-team
