### PR TITLE
STRF-6836 For helper should iterate once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Remove regex in cdnify.js to improve performance
 - Remove regex in fonts.js for better performance
 - Refactor functions away from arguments pattern for better performance
+- Fix for helper to allow for one iteration
 
 ## 4.0.6
 - Change default behavior of {{getFontsCollection}} to use font-display: swap for Google Fonts and allow configuration

--- a/helpers/for.js
+++ b/helpers/for.js
@@ -26,7 +26,7 @@ const factory = () => {
             }
         }
 
-        if (to <= from) {
+        if (to < from) {
             return;
         }
 

--- a/spec/helpers/for.js
+++ b/spec/helpers/for.js
@@ -10,6 +10,27 @@ describe('for helper', function() {
     // Build a test runner
     const runTestCases = testRunner({context});
 
+    it('should iterate once.', function(done) {
+        runTestCases([
+            {
+                input: '{{#for 1 this}}{{$index}}:{{name}} {{/for}}',
+                output: '1:Joe ',
+            },
+            {
+                input: '{{#for 1 1 this}}{{$index}}:{{name}} {{/for}}',
+                output: '1:Joe ',
+            },
+            {
+                input: '{{#for 0 0 this}}{{$index}}:{{name}} {{/for}}',
+                output: '0:Joe ',
+            },
+            {
+                input: '{{#for 1000 1000 this}}{{$index}}:{{name}} {{/for}}',
+                output: '1000:Joe ',
+            },
+        ], done);
+    });
+
     it('should iterate 10 times', function(done) {
         runTestCases([
             {


### PR DESCRIPTION
## What? Why?
STRF-6836 For helper should iterate once.  Previously for helper would iterate twice at the minimum and now it is able to iterate once at minimum.

Fixes #28 

## How was it tested?

----
Added unit tests and tests pass.
cc @bigcommerce/storefront-team
