### PR TITLE
STRF-6701 Renderer: reduce usage of Lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Remove regex in fonts.js for better performance
 - Refactor functions away from arguments pattern for better performance
 - Fix for helper to allow for one iteration
+- Reduce usage of Lodash to improve performance
 
 ## 4.0.6
 - Change default behavior of {{getFontsCollection}} to use font-display: swap for Google Fonts and allow configuration

--- a/helpers/all.js
+++ b/helpers/all.js
@@ -1,7 +1,5 @@
 'use strict';
-
-const _ = require('lodash');
-
+const common = require('./lib/common.js');
 /**
  * Yield block only if all arguments are valid
  *
@@ -12,22 +10,14 @@ const factory = () => {
     return function(...args) {
         // Take the last arg (which is a Handlebars options object) out of args array
         const opts = args.pop();
-
         // Check if all the arguments are valid / truthy
-        const result = _.all(args, function (arg) {
-            if (_.isArray(arg)) {
-                return !!arg.length;
+        let result;
+        for (let i = 0; i < args.length; i++) {
+            result = common.isTruthy(args[i]);
+            if (!result) {
+                break;
             }
-            // If an empty object is passed, arg is false
-            else if (_.isEmpty(arg) && _.isObject(arg)) {
-                return false;
-            }
-            // Everything else
-            else {
-                return !!arg;
-            }
-        });
-
+        }
         // If everything was valid, then "all" condition satisfied
         if (result) {
             return opts.fn(this);

--- a/helpers/deprecated/pick.js
+++ b/helpers/deprecated/pick.js
@@ -1,13 +1,19 @@
 'use strict';
 
-const _ = require('lodash');
-
 const factory = () => {
     /**
      * @deprecate
      */
-    return function() {
-        return _.pick.apply(null, arguments);
+    return function(obj, ...args) {
+        const pickedElements = {};
+
+        for (let i = 0; i < args.length; i++) {
+            const element = args[i];
+            if (obj.hasOwnProperty(element)) {
+                pickedElements[element] = obj[element];
+            }
+        }
+        return pickedElements;
     };
 };
 

--- a/helpers/for.js
+++ b/helpers/for.js
@@ -1,25 +1,21 @@
 'use strict';
 
-const _ = require('lodash');
+const common = require('./lib/common.js');
 
 const factory = () => {
     return function(from, to, context, options) {
         const maxIterations = 100;
         let output = '';
 
-        function isOptions(obj) {
-            return _.isObject(obj) && obj.fn;
-        }
-
-        if (isOptions(to)) {
+        if (common.isOptions(to)) {
             options = to;
             context = {};
             to = from;
             from = 1;
 
-        } else if (isOptions(context)) {
+        } else if (common.isOptions(context)) {
             options = context;
-            if (_.isObject(to)) {
+            if (common.isObject(to)) {
                 context = to;
                 to = from;
                 from = 1;

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,23 +1,20 @@
 'use strict';
-
-var _ = require('lodash');
+const common = require('./lib/common.js');
 
 const factory = globals => {
     return function(image, presetName, defaultImageUrl) {
-        var sizeRegex = /^(\d+?)x(\d+?)$/g;
-        var settings = globals.getThemeSettings() || {};
-        var presets = settings._images;
-        var size;
-        var width;
-        var height;
+        const sizeRegex = /^(\d+?)x(\d+?)$/g;
+        const settings = globals.getThemeSettings() || {};
+        const presets = settings._images;
+        let size, width, height;
 
-        if (!_.isPlainObject(image) || !_.isString(image.data) || image.data.indexOf('{:size}') === -1) {
+        if (!common.isObject(image) || !common.isString(image.data) || image.data.indexOf('{:size}') === -1) {
             // return empty string if not a valid image object
             defaultImageUrl = defaultImageUrl ? defaultImageUrl : '';
-            return _.isString(image) ? image : defaultImageUrl;
+            return common.isString(image) ? image : defaultImageUrl;
         }
 
-        if (_.isPlainObject(presets) && _.isPlainObject(presets[presetName])) {
+        if (common.isObject(presets) && common.isObject(presets[presetName])) {
             // If preset is one of the given presets in _images
             width = parseInt(presets[presetName].width, 10) || 4096;
             height = parseInt(presets[presetName].height, 10) || 4096;

--- a/helpers/if.js
+++ b/helpers/if.js
@@ -1,24 +1,20 @@
 'use strict';
 
-const _ = require('lodash');
+const common = require('./lib/common.js');
 
 const factory = globals => {
     return function(lvalue, operator, rvalue, options) {
         let result;
 
-        function isOptions(obj) {
-            return _.isObject(obj) && obj.fn;
-        }
-
         // Only parameter
-        if (isOptions(operator)) {
+        if (common.isOptions(operator)) {
             // If an array is passed as the only parameter
             options = operator;
-            if (_.isArray(lvalue)) {
+            if (Array.isArray(lvalue)) {
                 result = !!lvalue.length;
             }
             // If an empty object is passed, treat as false
-            else if (_.isEmpty(lvalue) && _.isObject(lvalue)) {
+            else if (common.isEmptyObject(lvalue)) {
                 result = false;
             }
             // Everything else
@@ -27,7 +23,7 @@ const factory = globals => {
             }
         } else {
 
-            if (isOptions(rvalue)) {
+            if (common.isOptions(rvalue)) {
                 // @TODO: this block is for backwards compatibility with 'compare' helper
                 // Remove after operator='==' is removed from stencil theme
                 options = rvalue;
@@ -102,3 +98,4 @@ module.exports = [{
     name: 'if',
     factory: factory,
 }];
+

--- a/helpers/lib/common.js
+++ b/helpers/lib/common.js
@@ -1,0 +1,33 @@
+function isObject(val) {
+    return val !== null && typeof val === 'object';
+}
+
+function isOptions(val) {
+    return isObject(val) && val.fn;
+}
+
+function isString(val) {
+    return typeof val === 'string';
+}
+
+function isEmptyObject(val) {
+    return isObject(val) && Object.keys(val).length === 0;
+}
+
+function isTruthy(val) {
+    if (Array.isArray(val)) {
+        return !!val.length;
+    } else if (isEmptyObject(val)) {
+        return false;
+    } else {
+        return !!val;
+    }
+}
+
+module.exports = {
+    isObject, 
+    isOptions, 
+    isString, 
+    isEmptyObject,
+    isTruthy
+};

--- a/helpers/limit.js
+++ b/helpers/limit.js
@@ -1,7 +1,5 @@
 'use strict';
-
-const _ = require('lodash');
-
+const common = require('./lib/common.js');
 /**
  * Limit an array to the second argument
  *
@@ -10,10 +8,10 @@ const _ = require('lodash');
  */
 const factory = () => {
     return function(data, limit) {
-        if (_.isString(data)) {
+        if (common.isString(data)) {
             return data.substring(0, limit);
         }
-        if (!_.isArray(data)) {
+        if (!Array.isArray(data)) {
             return [];
         }
 

--- a/helpers/money.js
+++ b/helpers/money.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * Format numbers
  *
@@ -10,7 +8,7 @@ const _ = require('lodash');
  * @param mixed   c: decimal delimiter
  */
 function numberFormat(value, n, s, c) {
-    var re = '\\d(?=(\\d{3})+' + (n > 0 ? '\\D' : '$') + ')',
+    let re = '\\d(?=(\\d{3})+' + (n > 0 ? '\\D' : '$') + ')',
         num = value.toFixed(Math.max(0, ~~n));
 
     return (c ? num.replace('.', c) : num).replace(new RegExp(re, 'g'), '$&' + (s || ','));
@@ -21,7 +19,7 @@ const factory = globals => {
         const siteSettings = globals.getSiteSettings();
         const money = siteSettings.money;
 
-        if (!_.isNumber(value)) {
+        if (typeof value !== 'number') {
             return '';
         }
 

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
-
+const common = require('./lib/common.js');
 /**
  * Yield block if any object within a collection matches supplied predicate
  *
@@ -12,21 +11,14 @@ const factory = () => {
     return function(...args) {
         // Take the last arg (which is a Handlebars options object) out of args array
         const opts = args.pop();
+        let any;
 
-        // Without options hash, we check all the arguments
-        const any = _.any(args, function (arg) {
-            if (_.isArray(arg)) {
-                return !!arg.length;
+        for (let i = 0; i < args.length; i++) {
+            any = common.isTruthy(args[i]);
+            if (any) {
+                break;
             }
-            // If an empty object is passed, arg is false
-            else if (_.isEmpty(arg) && _.isObject(arg)) {
-                return false;
-            }
-            // Everything else
-            else {
-                return !!arg;
-            }
-        });
+        }
 
         if (any) {
             return opts.fn(this);
@@ -34,7 +26,7 @@ const factory = () => {
 
         return opts.inverse(this);
     };
-};
+}
 
 module.exports = [{
     name: 'or',

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -1,6 +1,6 @@
+
 'use strict';
 
-const _ = require('lodash');
 const buildCDNHelper = require('./lib/cdnify');
 
 const factory = globals => {
@@ -16,16 +16,15 @@ const factory = globals => {
 
         const url = cdnify(path);
 
-        let attrs = { rel: 'stylesheet' };
+        const attrs = Object.assign({ rel: 'stylesheet' }, options.hash);
+        const attributeKeys = Object.keys(attrs);
+        const attributes = [];
 
-        // check if there is any extra attribute
-        if (_.isObject(options.hash)) {
-            attrs = _.merge(attrs, options.hash);
+        for (let i = 0; i < attributeKeys.length; i++) {
+            attributes.push(`${attributeKeys[i]}="${attrs[attributeKeys[i]]}"`);
         }
 
-        attrs = _.map(attrs, (value, key) => `${key}="${value}"`).join( ' ');
-
-        return `<link data-stencil-stylesheet href="${url}" ${attrs}>`;
+        return `<link data-stencil-stylesheet href="${url}" ${attributes.join(' ')}>`;
     };
 };
 


### PR DESCRIPTION
## What? Why?
STRF-6701 Renderer: Reduce usage of Lodash.  Lodash utility methods can be slow especially things like _.each and this is a pr to improve performance of Storefront Renderer by moving to native JavaScript methods and for loops.

## How was it tested?

----
Unit tests still pass.
cc @bigcommerce/storefront-team
