### PR TITLE
STRF-6701 Renderer: reduce usage of Lodash

### DIFF
--- a/helpers/thirdParty.js
+++ b/helpers/thirdParty.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const helpers = require('handlebars-helpers');
 
 const whitelist = [
@@ -145,16 +144,15 @@ const whitelist = [
 
 // Construct the data structure the caller expects: an array of { name, factory }
 const exportedHelpers = [];
-whitelist.forEach(whitelistSpec => {
+for (let i = 0; i < whitelist.length; i++) {
+    const whitelistSpec = whitelist[i];
     // Pluck whitelisted functions from each helper module.
-    const whitelistedHelpers = _.pick(helpers[whitelistSpec.name](), whitelistSpec.include);
-    _.each(whitelistedHelpers, (fn, name) => {
-        // Wrap with what the caller expects
-        exportedHelpers.push({
-            name: name,
-            factory: () => fn,
-        });
-    });
-});
+    const includelist = whitelistSpec.include;
+    const whitelistHelpers = helpers[whitelistSpec.name]();
+
+    for (let i = 0; i < includelist.length; i++) {
+        exportedHelpers.push({name: includelist[i], factory: () => whitelistHelpers[includelist[i]]});
+    }
+}
 
 module.exports = exportedHelpers;


### PR DESCRIPTION
## What? Why?
STRF-6701 Renderer: Reduce usage of Lodash. Lodash utility methods can be slow especially things like _.each and this is a pr to improve performance of Storefront Renderer by moving to native JavaScript methods and for loops.

## How was it tested?

----
The unit tests still pass.
cc @bigcommerce/storefront-team
