### PR TITLE
STRF-6701 Renderer: reduce Lodash usage

### DIFF
--- a/spec/helpers/any.js
+++ b/spec/helpers/any.js
@@ -7,13 +7,16 @@ const Lab = require('lab'),
 describe('any helper (with option hash)', function() {
     const context = {
         big: 'big',
-        arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
+        arrayWithObjs: [{a: 1},{b: 1},{a: 2}],
+        objWithObjs: {a: {a: true},b: {b: 1}, c: {a: 2}},
+        arrayWithMultipleObjs: [{a: {a:1, b:2}}, {b: {b:1, c:2}}],
+        objWithMultipleObjs: {a: {a:1, b:2}, b: {b:1, c:2}}
     };
 
     // Build a test runner that uses a default context
     const runTestCases = testRunner({context});
 
-    it('should return "big" with matching predicate ', function(done) {
+    it('should return "big" if every element of predicate is matched on an object', function(done) {
         runTestCases([
             {
                 input: '{{#any arrayWithObjs a=1}}{{big}}{{/any}}',
@@ -30,7 +33,24 @@ describe('any helper (with option hash)', function() {
         ], done);
     });
 
-    it('should return nothing without matching predicate ', function(done) {
+    it('should return "big" if every element of predicate is matched on an object', function(done) {
+        runTestCases([
+            {
+                input: '{{#any objWithObjs a=true}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any objWithObjs a=2}}{{big}}{{/any}}',
+                output: 'big',
+            },
+            {
+                input: '{{#any objWithObjs b=1}}{{big}}{{/any}}',
+                output: 'big',
+            },
+        ], done);
+    });
+
+    it('should return nothing without matching single predicate for an object', function(done) {
         runTestCases([
             {
                 input: '{{#any arrayWithObjs b=2}}{{big}}{{/any}}',
@@ -42,6 +62,75 @@ describe('any helper (with option hash)', function() {
             },
             {
                 input: '{{#any arrayWithObjs num=2}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return nothing without matching single predicate for an object', function(done) {
+        runTestCases([
+            {
+                input: '{{#any objWithObjs b=2}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any objWithObjs c=1}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any objWithObjs num=2}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return "big" if every element of predicate is matched on an object', function(done) {
+        runTestCases([
+            {
+                input: '{{#any arrayWithObjs b=2 a=1}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any arrayWithObjs c=2 b=1}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return nothing without matching all predicate for an object', function(done) {
+        runTestCases([
+            {
+                input: '{{#any arrayWithObjs b=2 a=3}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any arrayWithObjs c=1 d=5}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return "big" if every element of predicate is matched on an object', function(done) {
+        runTestCases([
+            {
+                input: '{{#any objWithObjs a=1 b=2}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any objWithObjs b=1 c=2}}{{big}}{{/any}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return nothing without matching all predicate for an object', function(done) {
+        runTestCases([
+            {
+                input: '{{#any objWithObjs b=2 b=9}}{{big}}{{/any}}',
+                output: '',
+            },
+            {
+                input: '{{#any objWithObjs c=1 d=6}}{{big}}{{/any}}',
                 output: '',
             },
         ], done);


### PR DESCRIPTION
## What? Why?
STRF-6701 Renderer: Reduce usage of Lodash. Lodash utility methods can be slow especially things like _.each and this is a pr to improve performance of Storefront Renderer by moving to native JavaScript methods and for loops.

## How was it tested?

----
Unit tests still pass also added unit tests for object iteration.
cc @bigcommerce/storefront-team
