### PR TITLE
Add configureImage helper

### DIFF
--- a/helpers/configureImage.js
+++ b/helpers/configureImage.js
@@ -1,0 +1,45 @@
+'use strict';
+const URL = require('url').URL;
+const utils = require('handlebars-utils');
+const common = require('./lib/common.js');
+
+const factory = () => {
+    return function(image, options) {
+        if (!utils.isObject(image) || !utils.isString(image.data) || !common.isValidURL(image.data)) {
+            // Return empty string if this does not appear to be an image object.
+            return ''
+        }
+
+        // 'https://cdn0.bigcommerce.com/s-hash/images/stencil/{:size}/l/some-image.original.jpg?c=2'
+        let url = new URL(image.data);
+        
+        //remove AIM query strings if already set by the application
+        url.searchParams.delete('imbypass');
+        url.searchParams.delete('imdevicesize');
+        url.searchParams.delete('imdeviceformat');
+
+        if (options && utils.isOptions((options))) {
+            if (options.hash['disable-all-optimizations']) {
+                // Add parameter to disable Akamai Image Manager optimization.
+                url.searchParams.set('imbypass', '1');
+                // Query string is now: 'c=2&imbypass=on'
+            } else {
+                if (options.hash['disable-device-sizing']) {
+                    url.searchParams.set('imdevicesize', '0');
+                }
+                if (options.hash['disable-device-formatting']) {
+                    url.searchParams.set('imdeviceformat', '0');
+                }
+            }
+        }
+        // Put special '{:size}' string back (it was URL encoded)
+        image.data = url.toString().replace('%7B:size%7D', '{:size}');
+
+        return image;
+    };
+};
+
+module.exports = [{
+    name: 'configureImage',
+    factory: factory,
+}];

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -24,6 +24,7 @@ describe('helper registration', () => {
             'cdn',
             'compare',
             'concat',
+            'configureImage',
             'contains',
             'dynamicComponent',
             'for',

--- a/spec/helpers/configureImage.js
+++ b/spec/helpers/configureImage.js
@@ -1,0 +1,116 @@
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
+
+describe('configureImage helper', function() {
+    const urlData = 'https://cdn.example.com/path/to/{:size}/image.png?c=2';
+    const urlData_imbypass = 'https://cdn.example.com/path/to/{:size}/image.png?c=2&imbypass=on';
+    const context = {
+        image_url: 'http://example.com/image.png',
+        not_an_image: null,
+        image: {
+            data: urlData
+        },
+        image_imbypass: {
+            data: urlData_imbypass
+        },
+        logoPreset: 'logo',
+    };
+
+    const themeSettings = {
+        logo_image: '600x300',
+    };
+
+    const runTestCases = testRunner({context, themeSettings});
+
+    it('should return blank if a URL is passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImage (configureImage "http://example.com/image.jpg" disable-all-optimizations=true)}}',
+                output: '',
+            },
+            {
+                input: '{{configureImage "http://example.com/image.jpg" disable-all-optimizations=true}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should reset the URL if no parameters are passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImage (configureImage image) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}`,
+            },
+            {
+                input: '{{getImage (configureImage image_imbypass) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300').replace('&imbypass=on', '')}`,
+            },
+        ], done);
+    });
+
+    it('should return a correct URL if truthy parameters are passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImage (configureImage image disable-all-optimizations=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imbypass=1`,
+            },
+            {
+                input: '{{getImage (configureImage image_imbypass disable-all-optimizations=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imbypass=1`,
+            },
+            {
+                input: '{{getImage (configureImage image disable-device-sizing=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imdevicesize=0`,
+            },
+            {
+                input: '{{getImage (configureImage image_imbypass disable-device-sizing=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imdevicesize=0`,
+            },
+            {
+                input: '{{getImage (configureImage image disable-device-formatting=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imdeviceformat=0`,
+            },
+            {
+                input: '{{getImage (configureImage image_imbypass disable-device-formatting=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imdeviceformat=0`,
+            },
+            {
+                input: '{{getImage (configureImage image disable-device-formatting=true disable-device-sizing=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imdevicesize=0&imdeviceformat=0`,
+            },
+            {
+                input: '{{getImage (configureImage image_imbypass disable-device-formatting=true disable-device-sizing=true) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}&imdevicesize=0&imdeviceformat=0`,
+            },
+
+        ], done);
+    });
+
+    it('should return a correct URL if falsy parameters are passed', function(done) {
+        runTestCases([
+            {
+                input: '{{getImage (configureImage image disable-all-optimizations=false) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}`,
+            },
+            {
+                input: '{{getImage (configureImage image_imbypass disable-all-optimizations=false) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300').replace('&imbypass=on', '')}`,
+            },
+            {
+                input: '{{getImage (configureImage image disable-device-sizing=false) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}`,
+            },
+            {
+                input: '{{getImage (configureImage image disable-device-formatting=false) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}`,
+            },
+            {
+                input: '{{getImage (configureImage image disable-device-formatting=false disable-device-sizing=false) "logo_image"}}',
+                output: `${urlData.replace('{:size}', '600x300')}`,
+            },
+        ], done);
+    });
+});


### PR DESCRIPTION
## What? Why?
Add new `configureImage` helper which can be used to control how optimizations are applied to CDN images.

This allows theme developers to selectively disable Akamai Image Manager's features which they may not want interfering with their image delivery in some cases.

Intended HTML usage:

`<img src="{{getImage (configureImage image disable-device-sizing-and-formatting=true)}}" />`

This depends on the changes from https://github.com/bigcommerce/paper-handlebars/pull/61, some of which I've pulled into this PR in order to make it work.

## How was it tested?
Unit tests

cc @bigcommerce/storefront-team @chrisboulton @karenwhite @bigcommerce/dev-docs 