### PR TITLE
(WIP) Add "localizePrice" helper

### DIFF
--- a/helpers/lib/icu-detect.js
+++ b/helpers/lib/icu-detect.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const hasFullICU = (() => {
+    try {
+        const january = new Date(9e8);
+        const spanish = new Intl.DateTimeFormat('es', { month: 'long' });
+        return spanish.format(january) === 'enero';
+    } catch (err) {
+        return false;
+    }
+})();
+
+module.exports = {
+    hasFullICU
+};

--- a/helpers/localizePrice.js
+++ b/helpers/localizePrice.js
@@ -1,0 +1,46 @@
+'use strict';
+const utils = require('handlebars-utils');
+// Detect ICU support
+const { hasFullICU } = require('./lib/icu-detect.js');
+
+const factory = () => {
+    return function(price, locale) {
+        if (!utils.isObject(price) || !utils.isString(price.currency)
+            || isNaN(price.value) || !utils.isString(price.formatted)) {
+            // Return empty string if this does not appear to be a price object
+            return '';
+        }
+
+        if (!utils.isString(locale) || locale.length < 2) {
+            // Valid browser language strings are at least two characters
+            // https://www.metamodpro.com/browser-language-codes
+            // If provided locale is less than two characters (or not a string),
+            // return the normal formatted price
+            return price.formatted;
+        }
+
+        // If the if full ICU is not installed, fall back to normal price
+        if (!hasFullICU){
+            return price.formatted;
+        }
+
+        // Try to format the price to the provided locale,
+        // but if anything goes wrong,
+        // just return the usual price
+        // Could happen if the full ICU is not installed,
+        // or if an invalid locale is provided.
+        try {
+            return new Intl.NumberFormat(
+                locale, { style: 'currency', currency: price.currency}
+            ).format(price.value);
+        }
+        catch (err){
+            return price.formatted;
+        }
+    };
+};
+
+module.exports = [{
+    name: 'localizePrice',
+    factory: factory,
+}];

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -50,6 +50,7 @@ describe('helper registration', () => {
             'lang',
             'langJson',
             'limit',
+            'localizePrice',
             'money',
             'nl2br',
             'occurrences',

--- a/spec/helpers/localizePrice.js
+++ b/spec/helpers/localizePrice.js
@@ -1,0 +1,38 @@
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      specHelpers = require('../spec-helpers'),
+      testRunner = specHelpers.testRunner
+
+describe('localizePrice helper', function() {
+    const context = {
+        "price": {
+            "tax_label": "GST",
+            "without_tax": {
+                "currency": "USD",
+                "formatted": "$123,456.78",
+                "value": 123456.78
+            }
+        }
+    };
+
+    const runTestCases = testRunner({context});
+
+    it('should return return correct prices across a number of locales', function(done) {
+        runTestCases([
+            {
+                input: '{{localizePrice price.without_tax "en-US"}}',
+                output: '$123,456.78',
+            },
+            {
+                input: '{{localizePrice price.without_tax "ja-JP"}}',
+                output: '$123,456.78',
+            },
+            {
+                input: '{{localizePrice price.without_tax "de"}}',
+                output: '123.456,78 $',
+            },
+        ], done);
+    });
+});


### PR DESCRIPTION
## What? Why?
Adds a new `localizePrice` helper which can be used to automatically configure the display of prices with the magic of [JavaScript's Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat).

This helper will override the behavior of store currency settings, and display prices differently according to the provided shopper locale - which can be supplied from browser language header we receive and make available via `request.locale`, or it can be specified statically in the theme. The helper will fall back to the normal stencil "formatted" price if we get any funky input.

The idea is that this will provide "magical" localization capabilities to Stencil, at least where we render pricing.

Since we're just using vanillaJS here, we can perfectly port this method to the frontend as well - for example where we [render PDP pricing from an API call](https://github.com/bigcommerce/cornerstone/blob/master/assets/js/theme/common/product-details.js#L499). So there's an opportunity for parity there.

Depends on:

https://github.com/bigcommerce/bigcommerce/pull/30545
https://github.com/bigcommerce/bigcommerce/pull/30582

## Usage example
----
Assume a price object that looks like this:
```
  "price": {
    "tax_label": "GST",
    "without_tax": {
      "formatted": "$23.00",
      "value": 23,
      "currency": "USD"
    }
  }
```

And a request object that looks like this:

```
  "request": {
    "absolute_path": "\/",
    "host": "ezra-haucks-store.my-staging.zone",
    "is_crawler": false,
    "locale": "en_US",
    "referer": false,
    "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/75.0.3770.100 Safari\/537.36"
  }
```

Usage would look like this: `{{localizePrice price.without_tax request.locale}}`

And output would be: `$23.00`

But if the request.locale changed to `fr-FR`, or if I manually specified it as such, this would output:

`23,00 $US`

## How was it tested?
----
Looking for feedback on approach before I add tests.

cc @bigcommerce/storefront-team @megdesko @bigcommerce/multi-currency @davidchin 
