### PR TITLE
STRF-6968 upgrade lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Upgrade Lodash to 4.17.13
 - Reduce usage of arguments
 
 ## 4.0.9

--- a/helpers/all.js
+++ b/helpers/all.js
@@ -15,7 +15,7 @@ const factory = () => {
         const opts = args.pop();
 
         // Check if all the args are valid / truthy
-        const result = _.all(args, function (arg) {
+        const result = _.every(args, function (arg) {
             if (_.isArray(arg)) {
                 return !!arg.length;
             }

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -17,12 +17,12 @@ const factory = () => {
         const predicate = opts.hash;
 
         if (!_.isEmpty(predicate)) {
-            // With options hash, we check the contents of first arg
-            any = _.any(args[0], predicate);
+            // With options hash, we check the contents of first argument
+            any = _.some(args[0], predicate);
         } else {
             // DEPRECATED: Moved to #or helper
-            // Without options hash, we check all the args
-            any = _.any(args, function (arg) {
+            // Without options hash, we check all the arguments
+            any = _.some(args, function (arg) {
                 if (_.isArray(arg)) {
                     return !!arg.length;
                 }

--- a/helpers/contains.js
+++ b/helpers/contains.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
 const factory = () => {
     return function(container, value) {
         const options = arguments[arguments.length - 1];
-        const contained = _.contains(container, value);
+        const contained = _.includes(container, value);
 
         // Yield block if true
         if (contained) {

--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -64,7 +64,7 @@ const fontProviders = {
 
             return {
                 google: {
-                    families: _.map(fonts, replaceSpaces),
+                    families: fonts.map(font => replaceSpaces(font)),
                 }
             };
         },

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -15,7 +15,7 @@ const factory = () => {
         const opts = args.pop();
 
         // Evaluate all args in args array to see if any are truthy
-        const any = _.any(args, function (arg) {
+        const any = _.some(args, function (arg) {
             if (_.isArray(arg)) {
                 return !!arg.length;
             }

--- a/helpers/pluck.js
+++ b/helpers/pluck.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 
 const factory = () => {
     return function(collection, path) {
-        return _.pluck(collection, path);
+        return _.map(collection, item => item[path]);
     };
 };
 

--- a/helpers/resourceHints.js
+++ b/helpers/resourceHints.js
@@ -33,7 +33,7 @@ const factory = globals => {
             }
         });
 
-        return new globals.handlebars.SafeString(_.map(hosts, format).join(''));
+        return new globals.handlebars.SafeString(hosts.map(host => format(host)).join(''));
     };
 };
 

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -20,10 +20,7 @@ const factory = globals => {
 
         let attrs = { rel: 'stylesheet' };
 
-        // check if there is any extra attribute
-        if (_.isObject(options.hash)) {
-            attrs = _.merge(attrs, options.hash);
-        }
+        Object.assign(attrs, options.hash);
 
         attrs = _.map(attrs, (value, key) => `${key}="${value}"`).join( ' ');
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "handlebars": "3.0.7",
     "handlebars-helpers": "0.8.4",
     "handlebars-utils": "^1.0.6",
-    "lodash": "^3.6.0",
+    "lodash": "^4.17.13",
     "stringz": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What? Why?
Upgrade Lodash due to known security vulnerability in 3.10.1.
https://jira.bigcommerce.com/browse/STRF-6968

An example of an article that mentions minimal performance difference is https://btux1984.wordpress.com/2018/10/06/why-you-should-still-embrace-lodash/
Based on this to gain a performance increase then we can only really do microoptimizations by refactoring everything to a for loop.

A response to https://codeburst.io/why-you-shouldnt-use-lodash-anymore-and-use-pure-javascript-instead-c397df51a66
https://medium.com/@cloud_guy/imo-lodash-is-not-bad-at-all-c8530d9da879

JS fiddle of that response: 
https://jsfiddle.net/o7g30d9r/

![image](https://user-images.githubusercontent.com/50118040/60561642-15f2a200-9d09-11e9-97eb-36157b599e8b.png)


## How was it tested?
----
The unit tests pass with the replacements of the deprecated functions.
cc @bigcommerce/storefront-team
