### PR TITLE
Return image URL as SafeString

### DIFF
--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var _ = require('lodash');
+const SafeString = require('handlebars').SafeString;
+const common = require('./lib/common.js');
 
 const factory = globals => {
     return function(image, presetName, defaultImageUrl) {
@@ -11,7 +13,8 @@ const factory = globals => {
         var width;
         var height;
 
-        if (!_.isPlainObject(image) || !_.isString(image.data) || image.data.indexOf('{:size}') === -1) {
+        if (!_.isPlainObject(image) || !_.isString(image.data)
+            || !common.isValidURL(image.data) || image.data.indexOf('{:size}') === -1) {
             // return empty string if not a valid image object
             defaultImageUrl = defaultImageUrl ? defaultImageUrl : '';
             return _.isString(image) ? image : defaultImageUrl;
@@ -19,8 +22,8 @@ const factory = globals => {
 
         if (_.isPlainObject(presets) && _.isPlainObject(presets[presetName])) {
             // If preset is one of the given presets in _images
-            width = parseInt(presets[presetName].width, 10) || 4096;
-            height = parseInt(presets[presetName].height, 10) || 4096;
+            width = parseInt(presets[presetName].width, 10) || 5120;
+            height = parseInt(presets[presetName].height, 10) || 5120;
             size = width + 'x' + height;
 
         } else if (sizeRegex.test(settings[presetName])) {
@@ -31,8 +34,7 @@ const factory = globals => {
             size = 'original';
         }
 
-        return image.data.replace('{:size}', size);
-
+        return new SafeString(image.data.replace('{:size}', size));
     };
 };
 

--- a/helpers/lib/common.js
+++ b/helpers/lib/common.js
@@ -1,0 +1,15 @@
+'use strict';
+const URL = require('url').URL;
+
+function isValidURL(val) {
+    try {
+        new URL(val);
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
+
+module.exports = {
+    isValidURL,
+};

--- a/spec/helpers/getImage.js
+++ b/spec/helpers/getImage.js
@@ -22,12 +22,16 @@ const themeSettings = {
 };
 
 describe('getImage helper', function() {
-    const urlData = 'https://cdn.example.com/path/to/{:size}/image.png';
+    const urlData = 'https://cdn.example.com/path/to/{:size}/image.png?c=2';
+    const urlData_2_qs = 'https://cdn.example.com/path/to/{:size}/image.png?c=2&imbypass=on';
     const context = {
         image_url: 'http://example.com/image.png',
         not_an_image: null,
         image: {
             data: urlData
+        },
+        image_with_2_qs: {
+            data: urlData_2_qs
         },
         logoPreset: 'logo',
     };
@@ -39,10 +43,6 @@ describe('getImage helper', function() {
             {
                 input: '{{getImage "http://example.com/image.jpg"}}',
                 output: 'http://example.com/image.jpg',
-            },
-            {
-                input: '{{getImage "https://example.com/image.jpg"}}',
-                output: 'https://example.com/image.jpg',
             },
         ], done);
     });
@@ -67,8 +67,16 @@ describe('getImage helper', function() {
                 output: urlData.replace('{:size}', '250x100'),
             },
             {
+                input: '{{getImage image_with_2_qs "logo"}}',
+                output: urlData_2_qs.replace('{:size}', '250x100'),
+            },
+            {
                 input: '{{getImage image "gallery"}}',
                 output: urlData.replace('{:size}', '300x300'),
+            },
+            {
+                input: '{{getImage image_with_2_qs "gallery"}}',
+                output: urlData_2_qs.replace('{:size}', '300x300'),
             },
         ], done);
     });
@@ -109,11 +117,11 @@ describe('getImage helper', function() {
         runTestCases([
             {
                 input: '{{getImage image "missing_values"}}',
-                output: urlData.replace('{:size}', '4096x4096'),
+                output: urlData.replace('{:size}', '5120x5120'),
             },
             {
                 input: '{{getImage image "missing_width"}}',
-                output: urlData.replace('{:size}', '4096x100'),
+                output: urlData.replace('{:size}', '5120x100'),
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?

Making getImage return a ` SafeString` instead of a string.

This is because `&` is a special character which gets escaped by Handlebars, which breaks query strings with more than 1 argument in image URLs.

This happens in production today with `imbypass`, example:

https://cdn11.bigcommerce.com/s-grief/images/stencil/1280x1280/products/7295/4490/122901_8k-wallpaper__18797.1558901341.jpg?c=3&amp;imbypass=on

Not that query string should be `?c=3&imbypass=on` but is instead `?c=3&amp;imbypass=on`.

We already have decent checking on this to make sure it's a real image object before we parse it, so this change feels okay to me - but I'm interested to hear from @mattolson on that.

I discovered this while testing https://github.com/bigcommerce/paper-handlebars/pull/53

## How was it tested?

Unit tests on getImage still pass, I added more test cases.

cc @bigcommerce/storefront-team
