### PR TITLE
Refactor lodash methods to use handlebars-utils instead

### DIFF
--- a/helpers/all.js
+++ b/helpers/all.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const utils = require('handlebars-utils');
 
 /**
  * Yield block only if all args are valid
@@ -16,11 +17,11 @@ const factory = () => {
 
         // Check if all the args are valid / truthy
         const result = _.every(args, function (arg) {
-            if (_.isArray(arg)) {
+            if (utils.isArray(arg)) {
                 return !!arg.length;
             }
             // If an empty object is passed, arg is false
-            else if (_.isEmpty(arg) && _.isObject(arg)) {
+            else if (utils.isEmpty(arg) && utils.isObject(arg)) {
                 return false;
             }
             // Everything else

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const utils = require('handlebars-utils');
 
 /**
  * Yield block if any object within a collection matches supplied predicate
@@ -16,18 +17,18 @@ const factory = () => {
         const opts = args.pop();
         const predicate = opts.hash;
 
-        if (!_.isEmpty(predicate)) {
+        if (!utils.isEmpty(predicate)) {
             // With options hash, we check the contents of first argument
             any = _.some(args[0], predicate);
         } else {
             // DEPRECATED: Moved to #or helper
             // Without options hash, we check all the arguments
             any = _.some(args, function (arg) {
-                if (_.isArray(arg)) {
+                if (utils.isArray(arg)) {
                     return !!arg.length;
                 }
                 // If an empty object is passed, arg is false
-                else if (_.isEmpty(arg) && _.isObject(arg)) {
+                else if (utils.isEmpty(arg) && utils.isObject(arg)) {
                     return false;
                 }
                 // Everything else

--- a/helpers/for.js
+++ b/helpers/for.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const utils = require('handlebars-utils');
 
 const factory = () => {
     return function(from, to, context) {
@@ -8,17 +8,13 @@ const factory = () => {
         const maxIterations = 100;
         var output = '';
 
-        function isOptions(obj) {
-            return _.isObject(obj) && obj.fn;
-        }
-
-        if (isOptions(to)) {
+        if (utils.isOptions(to)) {
             context = {};
             to = from;
             from = 1;
 
-        } else if (isOptions(context)) {
-            if (_.isObject(to)) {
+        } else if (utils.isOptions(context)) {
+            if (utils.isObject(to)) {
                 context = to;
                 to = from;
                 from = 1;

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('lodash');
+const utils = require('handlebars-utils');
 const SafeString = require('handlebars').SafeString;
 const common = require('./lib/common.js');
 
@@ -13,14 +13,14 @@ const factory = globals => {
         var width;
         var height;
 
-        if (!_.isPlainObject(image) || !_.isString(image.data)
+        if (!utils.isObject(image) || !utils.isString(image.data)
             || !common.isValidURL(image.data) || image.data.indexOf('{:size}') === -1) {
             // return empty string if not a valid image object
             defaultImageUrl = defaultImageUrl ? defaultImageUrl : '';
-            return _.isString(image) ? image : defaultImageUrl;
+            return utils.isString(image) ? image : defaultImageUrl;
         }
 
-        if (_.isPlainObject(presets) && _.isPlainObject(presets[presetName])) {
+        if (utils.isObject(presets) && utils.isObject(presets[presetName])) {
             // If preset is one of the given presets in _images
             width = parseInt(presets[presetName].width, 10) || 5120;
             height = parseInt(presets[presetName].height, 10) || 5120;

--- a/helpers/if.js
+++ b/helpers/if.js
@@ -1,24 +1,20 @@
 'use strict';
 
-const _ = require('lodash');
+const utils = require('handlebars-utils');
 
 const factory = globals => {
     return function(lvalue, operator, rvalue) {
         const options = arguments[arguments.length - 1];
         let result;
 
-        function isOptions(obj) {
-            return _.isObject(obj) && obj.fn;
-        }
-
         // Only parameter
-        if (isOptions(operator)) {
+        if (utils.isOptions(operator)) {
             // If an array is passed as the only parameter
-            if (_.isArray(lvalue)) {
+            if (utils.isArray(lvalue)) {
                 result = !!lvalue.length;
             }
             // If an empty object is passed, treat as false
-            else if (_.isEmpty(lvalue) && _.isObject(lvalue)) {
+            else if (utils.isEmpty(lvalue) && utils.isObject(lvalue)) {
                 result = false;
             }
             // Everything else
@@ -27,7 +23,7 @@ const factory = globals => {
             }
         } else {
 
-            if (isOptions(rvalue)) {
+            if (utils.isOptions(rvalue)) {
                 // @TODO: this block is for backwards compatibility with 'compare' helper
                 // Remove after operator='==' is removed from stencil theme
                 rvalue = operator;

--- a/helpers/limit.js
+++ b/helpers/limit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const utils = require('handlebars-utils');
 
 /**
  * Limit an array to the second argument
@@ -10,10 +10,10 @@ const _ = require('lodash');
  */
 const factory = () => {
     return function(data, limit) {
-        if (_.isString(data)) {
+        if (utils.isString(data)) {
             return data.substring(0, limit);
         }
-        if (!_.isArray(data)) {
+        if (!utils.isArray(data)) {
             return [];
         }
 

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const utils = require('handlebars-utils');
 
 /**
  * Yield block if any object within a collection matches supplied predicate
@@ -16,11 +17,11 @@ const factory = () => {
 
         // Evaluate all args in args array to see if any are truthy
         const any = _.some(args, function (arg) {
-            if (_.isArray(arg)) {
+            if (utils.isArray(arg)) {
                 return !!arg.length;
             }
             // If an empty object is passed, arg is false
-            else if (_.isEmpty(arg) && _.isObject(arg)) {
+            else if (utils.isEmpty(arg) && utils.isObject(arg)) {
                 return false;
             }
             // Everything else


### PR DESCRIPTION
## What? Why?
Swapping out lodash methods with handlebars-utils, which is a little nicer for handlebars.

## How was it tested?
Unit tests still pass.

----

cc @bigcommerce/storefront-team
