### PR TITLE
STRF-7011 Release 4.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
 ## Unreleased
+
+## 4.1.0
 - Upgrade Lodash to 4.17.13
-- Reduce usage of arguments
+- Reduce arguments usage where possible
+- Refactor helper functions to use Handlebars utils type checks instead of Lodash type checks
+- Add getImageSrcset helper
+- Refactor getImage helper to return image URL as SafeString instead of string
+
 
 ## 4.0.9
 - Revert "Refactor functions away from arguments pattern for better performance" from 4.0.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.0.9",
+  "version": "4.1.0",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
## What? Why?
Release 4.0.10
- Upgrade Lodash to 4.17.13
- Reduce arguments usage where possible
- Refactor helper functions to use Handlebars utils type checks instead of Lodash type checks
- Add getImageSrcset helper
- Refactor getImage helper to return image URL as SafeString instead of string

cc @bigcommerce/storefront-team
