### PR TITLE
Undo safestring change to getImage and release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 4.1.1
+- Revert usage of SafeString on getImage
+
 ## 4.1.0
 - Upgrade Lodash to 4.17.13
 - Reduce arguments usage where possible

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const utils = require('handlebars-utils');
-const SafeString = require('handlebars').SafeString;
 const common = require('./lib/common.js');
 
 const factory = globals => {
@@ -34,7 +33,7 @@ const factory = globals => {
             size = 'original';
         }
 
-        return new SafeString(image.data.replace('{:size}', size));
+        return image.data.replace('{:size}', size);
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/helpers/getImage.js
+++ b/spec/helpers/getImage.js
@@ -67,7 +67,7 @@ describe('getImage helper', function() {
                 output: urlData.replace('{:size}', '250x100'),
             },
             {
-                input: '{{getImage image_with_2_qs "logo"}}',
+                input: '{{{getImage image_with_2_qs "logo"}}}',
                 output: urlData_2_qs.replace('{:size}', '250x100'),
             },
             {
@@ -75,7 +75,7 @@ describe('getImage helper', function() {
                 output: urlData.replace('{:size}', '300x300'),
             },
             {
-                input: '{{getImage image_with_2_qs "gallery"}}',
+                input: '{{{getImage image_with_2_qs "gallery"}}}',
                 output: urlData_2_qs.replace('{:size}', '300x300'),
             },
         ], done);


### PR DESCRIPTION
## What? Why?
Surgical revert of https://github.com/bigcommerce/paper-handlebars/pull/61

SafeString on getImage caused some issues on production themes, with markup like this:

`{{#if (stripQuerystring (getImage ../product.main_image 'product_size' (cdn ../theme_settings.default_image_product))) '==' (stripQuerystring (getImage this 'product_size' (cdn ../theme_settings.default_image_product))) }}is-active is-main{{/if}}`

Un-doing it for now. Folks can use triple-braces in the meantime.

## How was it tested?
Unit tests, and confirmed in local dev that a previously broken theme is now fixed.


----

cc @bigcommerce/storefront-team
