### PR TITLE
Put getImage safestring back, release 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 4.1.2
+- Allow stripQuerystring to accept a Safestring as an argument
+- Refactor getImage helper to return image URL as SafeString instead of string
+
 ## 4.1.1
 - Revert usage of SafeString on getImage
 
@@ -11,7 +15,6 @@
 - Refactor helper functions to use Handlebars utils type checks instead of Lodash type checks
 - Add getImageSrcset helper
 - Refactor getImage helper to return image URL as SafeString instead of string
-
 
 ## 4.0.9
 - Revert "Refactor functions away from arguments pattern for better performance" from 4.0.7

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const utils = require('handlebars-utils');
+const SafeString = require('handlebars').SafeString;
 const common = require('./lib/common.js');
 
 const factory = globals => {
@@ -33,7 +34,7 @@ const factory = globals => {
             size = 'original';
         }
 
-        return image.data.replace('{:size}', size);
+        return new SafeString(image.data.replace('{:size}', size));
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/helpers/getImage.js
+++ b/spec/helpers/getImage.js
@@ -67,7 +67,7 @@ describe('getImage helper', function() {
                 output: urlData.replace('{:size}', '250x100'),
             },
             {
-                input: '{{{getImage image_with_2_qs "logo"}}}',
+                input: '{{getImage image_with_2_qs "logo"}}',
                 output: urlData_2_qs.replace('{:size}', '250x100'),
             },
             {
@@ -75,7 +75,7 @@ describe('getImage helper', function() {
                 output: urlData.replace('{:size}', '300x300'),
             },
             {
-                input: '{{{getImage image_with_2_qs "gallery"}}}',
+                input: '{{getImage image_with_2_qs "gallery"}}',
                 output: urlData_2_qs.replace('{:size}', '300x300'),
             },
         ], done);


### PR DESCRIPTION
## What? Why?

Putting the changes from https://github.com/bigcommerce/paper-handlebars/pull/61 back now that the bug with `stripQuerystring` has been fixed in https://github.com/bigcommerce/paper-handlebars/pull/67. Releasing 4.1.2.

## How was it tested?
Unit tests.

cc @bigcommerce/storefront-team
