### PR TITLE
Only generate srcsets up to the dimensions of the image (if known)

### DIFF
--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -24,14 +24,20 @@ const factory = globals => {
             // If preset is one of the given presets in _images
             width = parseInt(presets[presetName].width, 10) || 5120;
             height = parseInt(presets[presetName].height, 10) || 5120;
-            size = width + 'x' + height;
-
+            size = `${width}x${height}`;
         } else if (sizeRegex.test(settings[presetName])) {
             // If preset name is a setting and match the NNNxNNN format
             size = settings[presetName];
+            width = parseInt(size.split('x')[0], 10);
+            height = parseInt(size.split('x')[1], 10);
         } else {
             // Use the original image size
             size = 'original';
+        }
+
+        if (Number.isInteger(image.width) && Number.isInteger(image.height)
+            && Number.isInteger(width) && Number.isInteger(height)) {
+            size = `${Math.min(image.width, width)}x${Math.min(image.height, height)}`
         }
 
         return new SafeString(image.data.replace('{:size}', size));

--- a/helpers/getImageSrcset.js
+++ b/helpers/getImageSrcset.js
@@ -26,16 +26,29 @@ const factory = () => {
         let srcsets = {};
 
         if (options.hash['use_default_sizes']) {
-            srcsets = {
-                '2560w': '2560w',
-                '1920w': '1920w',
-                '1280w': '1280w',
-                '960w': '960w',
-                '640w': '640w',
-                '320w': '320w',
-                '160w': '160w',
-                '80w': '80w',
-            };
+            if (Number.isInteger(image.width) && Number.isInteger(image.height)){
+                /* If we know the image dimensions, don't generate srcset sizes larger than the image  */
+                srcsets[`${image.width}w`] = `${image.width}w`;
+                const defaultSrcsetSizes = [2560, 1920, 1280, 960, 640, 320, 160, 80];
+                defaultSrcsetSizes.forEach(width => {
+                    if (width < image.width) {
+                        srcsets[`${width}w`] = `${width}w`;
+                    }
+                });
+            } else {
+                /* If we DON'T know the image dimensions, generate a default set of srcsets
+                *  This will upsize images */
+                srcsets = {
+                    '2560w': '2560w',
+                    '1920w': '1920w',
+                    '1280w': '1280w',
+                    '960w': '960w',
+                    '640w': '640w',
+                    '320w': '320w',
+                    '160w': '160w',
+                    '80w': '80w',
+                };
+            }
         } else {
             srcsets = options.hash;
             if (!utils.isObject(srcsets) || Object.keys(srcsets).some(descriptor => {

--- a/spec/helpers/getImage.js
+++ b/spec/helpers/getImage.js
@@ -28,7 +28,14 @@ describe('getImage helper', function() {
         image_url: 'http://example.com/image.png',
         not_an_image: null,
         image: {
-            data: urlData
+            data: urlData,
+            width: null,
+            height: null,
+        },
+        image_with_dimensions: {
+            data: urlData,
+            width: 123,
+            height: 123,
         },
         image_with_2_qs: {
             data: urlData_2_qs
@@ -112,7 +119,6 @@ describe('getImage helper', function() {
         ], done);
     });
 
-
     it('should default to max value (width & height) if value is not provided', function(done) {
         runTestCases([
             {
@@ -122,6 +128,19 @@ describe('getImage helper', function() {
             {
                 input: '{{getImage image "missing_width"}}',
                 output: urlData.replace('{:size}', '5120x100'),
+            },
+        ], done);
+    });
+
+    it('should default to size of the image dimensions if known and a larger size is requested', function(done) {
+        runTestCases([
+            {
+                input: '{{getImage image_with_dimensions "logo"}}',
+                output: urlData.replace('{:size}', '123x100'),
+            },
+            {
+                input: '{{getImage image_with_dimensions "logo_image"}}',
+                output: urlData.replace('{:size}', '123x123'),
             },
         ], done);
     });

--- a/spec/helpers/getImageSrcset.js
+++ b/spec/helpers/getImageSrcset.js
@@ -14,7 +14,14 @@ describe('getImageSrcset helper', function() {
             data: urlData
         },
         image_with_2_qs: {
-            data: urlData_2_qs
+            data: urlData_2_qs,
+            width: null,
+            height: null,
+        },
+        image_with_dimensions: {
+            data: urlData,
+            width: 1400,
+            height: 900,
         },
     };
 
@@ -42,6 +49,15 @@ describe('getImageSrcset helper', function() {
             {
                 input: '{{getImageSrcset image use_default_sizes=true}}',
                 output: 'https://cdn.example.com/path/to/80w/image.png?c=2 80w, https://cdn.example.com/path/to/160w/image.png?c=2 160w, https://cdn.example.com/path/to/320w/image.png?c=2 320w, https://cdn.example.com/path/to/640w/image.png?c=2 640w, https://cdn.example.com/path/to/960w/image.png?c=2 960w, https://cdn.example.com/path/to/1280w/image.png?c=2 1280w, https://cdn.example.com/path/to/1920w/image.png?c=2 1920w, https://cdn.example.com/path/to/2560w/image.png?c=2 2560w',
+            },
+        ], done);
+    });
+
+    it('should return a srcset made of default sizes up to the width of the image if known', function(done) {
+        runTestCases([
+            {
+                input: '{{getImageSrcset image_with_dimensions use_default_sizes=true}}',
+                output: 'https://cdn.example.com/path/to/80w/image.png?c=2 80w, https://cdn.example.com/path/to/160w/image.png?c=2 160w, https://cdn.example.com/path/to/320w/image.png?c=2 320w, https://cdn.example.com/path/to/640w/image.png?c=2 640w, https://cdn.example.com/path/to/960w/image.png?c=2 960w, https://cdn.example.com/path/to/1280w/image.png?c=2 1280w, https://cdn.example.com/path/to/1400w/image.png?c=2 1400w',
             },
         ], done);
     });

--- a/spec/helpers/if.js
+++ b/spec/helpers/if.js
@@ -183,7 +183,7 @@ describe('if helper', () => {
         ], done)
     });
 
-    it('should throw an exeption when non string value sent to gtnum', function (done) {
+    it('should throw an exception when non string value sent to gtnum', function (done) {
         renderString('{{#if num1 "gtnum" "2"}}big{{/if}}').catch(e => {
             renderString('{{#if "2" "gtnum" num2}}big{{/if}}').catch(e => {
                 renderString('{{#if num1 "gtnum" num2}}big{{/if}}').catch(e => {
@@ -193,7 +193,7 @@ describe('if helper', () => {
         });
     });
 
-    it('should throw an exeption when NaN value sent to gtnum', function (done) {
+    it('should throw an exception when NaN value sent to gtnum', function (done) {
         renderString('{{#if "aaaa" "gtnum" "2"}}big{{/if}}').catch(e => {
             renderString('{{#if "2" "gtnum" "bbbb"}}big{{/if}}').catch(e => {
                 renderString('{{#if "aaaa" "gtnum" "bbbb"}}big{{/if}}').catch(e => {


### PR DESCRIPTION
## What? Why?
Modify behavior of `getImageSrcset` to only generate srcsets up to the size of the image, *if* we know the image dimensions.

Assumes we'll make updates to pass the dimensions of images into the context in the future.

Today, we could do this for carousel images, which should help optimize home page load speed and reduce inefficiency in the HTML if carousel images less than our maximum sizes are uploaded.

## How was it tested?

Added unit test.

## Todo (maybe in other PRs)

- [ ] Make this work when non-default sizes are used
- [x] Do the same thing to `getImage`

----

cc @bigcommerce/storefront-team
