### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.2.0
+- Add setURLQueryParam helper
+- Make getImageSrcset not generate default srcsets larger than the original image when the dimensions are known
+- Make getImage not generate an image larger than the dimensions of the original image if the dimensions are known
+
 ## 4.1.2
 - Allow stripQuerystring to accept a Safestring as an argument
 - Refactor getImage helper to return image URL as SafeString instead of string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Releasing 4.2.0 so we can publish to NPM.

cc @bigcommerce/storefront-team
