### PR TITLE
Fix json helper to work with a nested getImage helper

### DIFF
--- a/helpers/json.js
+++ b/helpers/json.js
@@ -1,7 +1,11 @@
 'use strict';
+const SafeString = require('handlebars').SafeString;
 
 const factory = () => {
     return function(data) {
+        if (data instanceof SafeString) {
+            data = data.toString();
+        }
         return JSON.stringify(data);
     };
 };

--- a/spec/helpers/json.js
+++ b/spec/helpers/json.js
@@ -5,7 +5,11 @@ const Lab = require('lab'),
       testRunner = require('../spec-helpers').testRunner;
 
 describe('json helper', function() {
+    const urlData_2_qs = 'https://cdn.example.com/path/to/{:size}/image.png?c=2&imbypass=on';
     const context = {
+        image_with_2_qs: {
+            data: urlData_2_qs
+        },
         object: { a: 1, b: "hello" }
     };
 
@@ -16,6 +20,14 @@ describe('json helper', function() {
             {
                 input: '{{{json object}}}',
                 output: '{"a":1,"b":"hello"}',
+            },
+        ], done);
+    });
+    it('should work together with getImage', function(done) {
+        runTestCases([
+            {
+                input: '{{{json (getImage image_with_2_qs)}}}',
+                output: '"https://cdn.example.com/path/to/original/image.png?c=2&imbypass=on"',
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?
A partner has reported an issue using the `{{getImage}}` helper as a nested expression on the `{{json}}` helper: https://support.bigcommerce.com/s/question/0D51B00005aDurSSAS/sudden-change-in-how-stencil-json-getimage-works

This fixes that by first unwrapping `SafeString`s before processing.

This doesn't really violate the object model in my opinion, as these are handlebars rendering internal details.

## How was it tested?
Added a unit test.

----

cc @bigcommerce/storefront-team
