### PR TITLE
STRF-7393 fix addTemplates logic to not lose templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 4.2.2
+- Fix addTemplates logic in order to not lose templates on renderTheme function for Stencil CLI
+
 ## 4.2.1
 - Allow json helper to accept a SafeString as an argument
 - Move SafeString unwrapping to common module

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ class HandlebarsRenderer {
             const path = paths[i];
 
             if (typeof this.handlebars.partials[path] !== 'undefined') {
-                return;
+                continue;
             }
 
             try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
## What? Why?
https://jira.bigcommerce.com/browse/STRF-7393
There was an issue with the addTemplates function that caused stencil cli to lose templates when paper was on the 3.x branch this pr should fix the issue. 

## How was it tested?
Stencil cli add to cart, edit cart and delete cart along with other JavaScript functionality works as expected now with the paper 3.x branch when tested locally
----

cc @bigcommerce/storefront-team
