### PR TITLE
Import Url, not undefined URL

### DIFF
--- a/helpers/lib/common.js
+++ b/helpers/lib/common.js
@@ -1,5 +1,5 @@
 'use strict';
-const URL = require('url').URL;
+const URL = require('url').Url;
 const SafeString = require('handlebars').SafeString;
 
 function isValidURL(val) {


### PR DESCRIPTION
## What? Why?
I was trying to use the `getImageSrcset` helper on the frontend within a vue application. It wasn't working because the helper always though the url was invalid. After investigating, I found that the `.URL` property does not exist on the `url` module. I am not sure how this was working at all, but I changed the import to `.Url` because that is the proper key for the module.

After making this change, everything worked as expected.



## How was it tested?

After making the change, the import worked correctly. I am using this on the frontend, so you would have to confirm it doesn't cause any issues within stencil. I can't imagine it would. Maybe the server does some sort of automatic case-insensitive search for the key, which is why the issue went unnoticed until I tried to use it on the frontend.

----

cc @bigcommerce/storefront-team
