### PR TITLE
Add encodeHtmlEntities helper

### DIFF
--- a/helpers/encodeHtmlEntities.js
+++ b/helpers/encodeHtmlEntities.js
@@ -1,0 +1,21 @@
+'use strict';
+const he = require('he');
+const utils = require('handlebars-utils');
+const common = require('./lib/common.js');
+const SafeString = require('handlebars').SafeString;
+
+const factory = () => {
+    return function(string) {
+        string = common.unwrapIfSafeString(string);
+        if (!utils.isString(string)){
+            throw new TypeError("Non-string passed to encodeHtmlEntities");
+        }
+
+        return new SafeString(he.encode(string));
+    };
+};
+
+module.exports = [{
+    name: 'encodeHtmlEntities',
+    factory: factory,
+}];

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "handlebars": "3.0.7",
     "handlebars-helpers": "0.8.4",
     "handlebars-utils": "^1.0.6",
+    "he": "^1.2.0",
     "lodash": "^4.17.13",
     "stringz": "^0.1.1"
   },

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -26,6 +26,7 @@ describe('helper registration', () => {
             'concat',
             'contains',
             'dynamicComponent',
+            'encodeHtmlEntities',
             'for',
             'getFontLoaderConfig',
             'getFontsCollection',

--- a/spec/helpers/encodeHtmlEntities.js
+++ b/spec/helpers/encodeHtmlEntities.js
@@ -1,0 +1,31 @@
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      specHelpers = require('../spec-helpers'),
+      testRunner = specHelpers.testRunner;
+
+describe('setURLQueryParam helper', function() {
+    const context = {
+        string: 'foo © bar ≠ baz 𝌆 qux',
+    };
+
+    const runTestCases = testRunner({context});
+
+    it('should return a string with HTML entities encoded', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux"}}',
+                output: `foo &#xA9; bar &#x2260; baz &#x1D306; qux`,
+            },
+            {
+                input: '{{encodeHtmlEntities string}}',
+                output: `foo &#xA9; bar &#x2260; baz &#x1D306; qux`,
+            },
+            {
+                input: '{{encodeHtmlEntities "string"}}',
+                output: `string`,
+            },
+        ], done);
+    });
+});


### PR DESCRIPTION
## What? Why?
Add new helper for encoding HTML entities. Needed to safe some strings in Cornerstone.

## How was it tested?
Unit test added.

----

cc @bigcommerce/storefront-team @lord2800 
