### PR TITLE
Add the arguments that `he` supports on encodeHtmlEntities

### DIFF
--- a/helpers/encodeHtmlEntities.js
+++ b/helpers/encodeHtmlEntities.js
@@ -11,7 +11,29 @@ const factory = () => {
             throw new TypeError("Non-string passed to encodeHtmlEntities");
         }
 
-        return new SafeString(he.encode(string));
+        const options = arguments[arguments.length - 1];
+
+        let args = {};
+
+        if (utils.isOptions(options)) {
+            args = options.hash;
+
+            // Whitelist of allowed named arguments into `he` function
+            const allowedArguments = [
+                'useNamedReferences',
+                'decimal',
+                'encodeEverything',
+                'allowUnsafeSymbols'
+            ];
+
+            // Make sure all named arguments from options hash are in the whitelist and have boolean (string) values
+            if (Object.keys(args).some(key => !allowedArguments.includes(key))
+                || !Object.keys(args).map(key => args[key]).every(val => ['true', 'false'].includes(val))) {
+                throw new TypeError("Invalid named argument passed to encodeHtmlEntities");
+            }
+        }
+
+        return new SafeString(he.encode(string, args));
     };
 };
 

--- a/spec/helpers/encodeHtmlEntities.js
+++ b/spec/helpers/encodeHtmlEntities.js
@@ -3,7 +3,9 @@ const Lab = require('lab'),
       describe = lab.experiment,
       it = lab.it,
       specHelpers = require('../spec-helpers'),
-      testRunner = specHelpers.testRunner;
+      testRunner = specHelpers.testRunner,
+      renderString = specHelpers.renderString;
+
 
 describe('encodeHtmlEntities helper', function() {
     const context = {
@@ -12,6 +14,8 @@ describe('encodeHtmlEntities helper', function() {
     };
 
     const runTestCases = testRunner({context});
+
+    // Some test cases lifted from https://github.com/mathiasbynens/he
 
     it('should return a string with HTML entities encoded', function(done) {
         runTestCases([
@@ -36,5 +40,73 @@ describe('encodeHtmlEntities helper', function() {
                 output: `an ampersand: &#x26;`,
             },
         ], done);
+    });
+
+    it('should return a string with HTML entities encoded with named references', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" useNamedReferences="true"}}',
+                output: `foo &copy; bar &ne; baz &#x1D306; qux`,
+            },
+        ], done);
+    });
+
+    it('should return a string with HTML entities encoded with decimal option', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" decimal="true"}}',
+                output: `foo &#169; bar &#8800; baz &#119558; qux`,
+            },
+        ], done);
+    });
+
+    it('should return a string with HTML entities encoded with named references and decimal option', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" useNamedReferences="true" decimal="true"}}',
+                output: `foo &copy; bar &ne; baz &#119558; qux`,
+            },
+        ], done);
+    });
+
+    it('should return a string with HTML entities encoded with encodeEverything option', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" encodeEverything="true"}}',
+                output: `&#x66;&#x6F;&#x6F;&#x20;&#xA9;&#x20;&#x62;&#x61;&#x72;&#x20;&#x2260;&#x20;&#x62;&#x61;&#x7A;&#x20;&#x1D306;&#x20;&#x71;&#x75;&#x78;`,
+            },
+        ], done);
+    });
+
+    it('should return a string with HTML entities encoded with encodeEverything and useNamedReferences option', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" encodeEverything="true" useNamedReferences="true"}}',
+                output: `&#x66;&#x6F;&#x6F;&#x20;&copy;&#x20;&#x62;&#x61;&#x72;&#x20;&ne;&#x20;&#x62;&#x61;&#x7A;&#x20;&#x1D306;&#x20;&#x71;&#x75;&#x78;`,
+            },
+        ], done);
+    });
+
+    it('should return a string with HTML entities encoded with allowUnsafeSymbols option', function(done) {
+        runTestCases([
+            {
+                input: '{{encodeHtmlEntities "foo © and & ampersand" allowUnsafeSymbols="true"}}',
+                output: `foo &#xA9; and & ampersand`,
+            },
+        ], done);
+    });
+
+    it('should throw an exception if an invalid named argument is passed', function (done) {
+        renderString('{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" useNamedReferences="blah"}}').catch(e => {
+            renderString('{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux" blah="true"}}').catch(e => {
+                done();
+            });
+        });
+    });
+
+    it('should throw an exception if a non-string argument is passed', function (done) {
+        renderString('{{encodeHtmlEntities 123}}').catch(e => {
+            done();
+        });
     });
 });


### PR DESCRIPTION
## What? Why?
Add support for more of the arguments on `he` module for more flexibility in HTML encoding.

I added support for [all of these arguments](https://github.com/mathiasbynens/he#heencodetext-options) except `strict` because I don't think it's useful in this context.

## How was it tested?
Unit tests.

----

cc @bigcommerce/storefront-team
