### PR TITLE
Allow replace helper to handle safestrings

### DIFF
--- a/helpers/replace.js
+++ b/helpers/replace.js
@@ -1,7 +1,10 @@
 'use strict';
+const common = require('./lib/common.js');
 
 const factory = () => {
     return function(needle, haystack) {
+        needle = common.unwrapIfSafeString(needle);
+        haystack = common.unwrapIfSafeString(haystack);
         const options = arguments[arguments.length - 1];
 
         if (typeof needle !== 'string') {

--- a/spec/helpers/replace.js
+++ b/spec/helpers/replace.js
@@ -12,6 +12,7 @@ describe('replace helper', function() {
     const context = {
         content: "Either you run the %%var%% or the  %%var%% runs you",
         price: '$49.99',
+        facet: 'brand',
     };
 
     const runTestCases = testRunner({context, templates});
@@ -48,6 +49,15 @@ describe('replace helper', function() {
             {
                 input: "{{#replace '$' '$10.00'}}USD {{/replace}}",
                 output: 'USD 10.00',
+            },
+        ], done);
+    });
+
+    it('should work nicely with other helpers that use safestring', function(done) {
+        runTestCases([
+            {
+                input: "Replace+Concat+Hyphenated: fifth-{{#replace '&' (concat '&' (hyphenate facet)) }}{{/replace}}",
+                output: "Replace+Concat+Hyphenated: fifth-brand",
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?
Unwrap `safestring` inputs to `replace` helper, so it can be used more gracefully with other helpers.

## How was it tested?
Unit tests.
----

cc @bigcommerce/storefront-team @bigcommerce/artemis-dt 
