### PR TITLE
STRF-8585 Escape injected values

### DIFF
--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -9,8 +9,13 @@ const factory = globals => {
             if (typeof value === 'string') {
                 result = globals.handlebars.escapeExpression(value);
             }
-            if (typeof value === 'object' && value !== null) {
+            if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
                 result = filterObjectValues(value);
+            }
+            if (Array.isArray(value)) {
+                result = value.map(item => {
+                    return filterValues(item);
+                });
             }
         }
         return result;
@@ -18,16 +23,7 @@ const factory = globals => {
     function filterObjectValues(obj) {
         let filteredObject = {};
         Object.keys(obj).forEach(key => {
-            if (typeof obj[key] === 'string') {
-                filteredObject[key] = globals.handlebars.escapeExpression(obj[key]);
-                return;
-            }
-            if (typeof obj[key] === 'object' && obj[key] !== null) {
-                filteredObject[key] = filterObjectValues(obj[key]);
-                return;
-            } else {
-                filteredObject[key] = obj[key];
-            }
+            filteredObject[key] = filterValues(obj[key]);
         });
         return filteredObject;
     }

--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -1,6 +1,37 @@
 'use strict';
 
 const factory = globals => {
+    function filterValues(value) {
+        let result = value;
+        try {
+            JSON.parse(value);
+        } catch (e) {
+            if (typeof value === 'string') {
+                result = globals.handlebars.escapeExpression(value);
+            }
+            if (typeof value === 'object' && value !== null) {
+                result = filterObjectValues(value);
+            }
+        }
+        return result;
+    }
+    function filterObjectValues(obj) {
+        let filteredObject = {};
+        Object.keys(obj).forEach(key => {
+            if (typeof obj[key] === 'string') {
+                filteredObject[key] = globals.handlebars.escapeExpression(obj[key]);
+                return;
+            }
+            if (typeof obj[key] === 'object' && obj[key] !== null) {
+                filteredObject[key] = filterObjectValues(obj[key]);
+                return;
+            } else {
+                filteredObject[key] = obj[key];
+            }
+        });
+        return filteredObject;
+    }
+
     return function(key, value) {
         if (typeof value === 'function') {
             return;
@@ -12,7 +43,7 @@ const factory = globals => {
         }
 
         // Store value for later use by jsContext
-        globals.storage.inject[key] = value;
+        globals.storage.inject[key] = filterValues(value);
     };
 };
 

--- a/spec/helpers/inject.js
+++ b/spec/helpers/inject.js
@@ -8,6 +8,17 @@ describe('inject helper', function() {
     const context = {
         value1: "Big",
         value2: "Commerce",
+        badChars: "&<>\"'`",
+        jsonString: JSON.stringify({"big": "commerce"}),
+        nested: {
+            firstName: "&<>",
+            lastName: "\"'`",
+            addresses: [
+                {
+                    street: "123 &<>\"'` St"
+                }
+            ],
+        },
     };
 
     const runTestCases = testRunner({context});
@@ -20,4 +31,32 @@ describe('inject helper', function() {
             },
         ], done);
     });
+
+    it('should escape strings', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'filtered' badChars}}{{jsContext}}",
+                output: '"{\\"filtered\\":\\"&amp;&lt;&gt;&quot;&#x27;&#x60;\\"}"',
+            }
+        ], done);
+    });
+
+    it('should exclude JSON strings from filtering', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'filtered' jsonString}}{{jsContext}}",
+                output: '"{\\"filtered\\":\\"{\\\\\\"big\\\\\\":\\\\\\"commerce\\\\\\"}\\"}"',
+            }
+        ], done);
+    });
+
+    it('should escape strings nested in objects and arrays', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'filtered' nested}}{{jsContext}}",
+                output: '"{\\"filtered\\":{\\"firstName\\":\\"&amp;&lt;&gt;\\",\\"lastName\\":\\"&quot;&#x27;&#x60;\\",\\"addresses\\":[{\\"street\\":\\"123 &amp;&lt;&gt;&quot;&#x27;&#x60; St\\"}]}}"',
+            }
+        ], done);
+    });
+
 });


### PR DESCRIPTION
## What? 
Escaping values passed into jsContext through the inject helper using Handlebars escapeExpression.

## Why?
Currently, users can enter values on the account page that aren't escaped, potentially opening up site visitors to XSS attacks when the values are injected into jsContext.

By escaping the values as they are injected, any unsafe values (i.e. script tags) will be rendered as plain text on the page, even if a developer is feeding them into the page with innerHTML.

## How was it tested?
Used my fork of paper-handlebars within a locally referenced version of paper with storefront-renderer running in VM. I uploaded a customized version of the latest Cornerstone to my VM store with extra account values injected on the page so I could see them in the browser inspect element console.

Injected fields:
![image](https://user-images.githubusercontent.com/16565458/95271071-93f20280-0802-11eb-8b59-7e2526c98e7f.png)

Example of account page with unsafe characters:
![image](https://user-images.githubusercontent.com/16565458/95271134-c00d8380-0802-11eb-9d5d-89d546499fc3.png)

Example of customer address with unsafe characters:
![image](https://user-images.githubusercontent.com/16565458/95271160-ce5b9f80-0802-11eb-86a4-24febb596f20.png)

Output of jsContext:
![image](https://user-images.githubusercontent.com/16565458/95271250-095dd300-0803-11eb-9dc8-b2c6f0411ebd.png)



----

cc @bigcommerce/storefront-team
cc @junedkazi 
