### PR TITLE
PEN-2052: Performance improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ class HandlebarsRenderer {
         // be a string representation of an object containing a `main`
         // function and a `compiler` array. We do this because the next
         // step is a potentially dangerous eval.
-        const re = /"compiler":\[.*\],"main":function/;
+        const re = /"compiler":\[.+?\],"main":function/;
         if (!re.test(precompiled)) {
             // This is not a valid precompiled template, so this is
             // a raw template that can be registered directly.

--- a/index.js
+++ b/index.js
@@ -202,14 +202,15 @@ class HandlebarsRenderer {
             return precompiled;
         }
 
-        // We need to take the string representation and turn it into a
-        // valid JavaScript object. eval is evil, but necessary in this case.
-        let template;
-        eval(`template = ${precompiled}`);
+        // We need to take the string representation of the precompiled template
+        // object and turn it into a valid JavaScript object. We use `new Function`
+        // rather than `eval` based on this advice:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Never_use_eval!
+        const template = Function(`"use strict";return (${precompiled});`);
 
-        // Take the precompiled object and get the actual function out of it,
+        // Take the precompiled template object and get the actual function out of it,
         // after first testing for runtime version compatibility.
-        return this.handlebars.template(template);
+        return this.handlebars.template(template());
     }
 
     /**


### PR DESCRIPTION
## What? Why?
* Change precompiled template regular expression to lazy instead of greedy
* Change loading procedure for precompiled templates. Instead of `eval`, use `Function()` based on the advice here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Never_use_eval!

## How was it tested?
Tested locally but need to get into integration environment for better cpu profiling

----

cc @bigcommerce/storefront-team
