### PR TITLE
Append CDN fingerprint to assets using CDN helpers

### DIFF
--- a/helpers/getContentImage.js
+++ b/helpers/getContentImage.js
@@ -6,10 +6,11 @@ const factory = globals => {
         const siteSettings = globals.getSiteSettings();
 
         const cdnUrl = siteSettings.cdn_url || '';
+        const contentFolderFingerprint = siteSettings.content_folder_fingerprint || '';
 
         const options = arguments[arguments.length - 1];
 
-        return getObjectStorageImage(cdnUrl, 'content', path, options);
+        return getObjectStorageImage(cdnUrl, 'content', path, options, contentFolderFingerprint);
     };
 };
 

--- a/helpers/getContentImageSrcset.js
+++ b/helpers/getContentImageSrcset.js
@@ -6,8 +6,9 @@ const factory = globals => {
         const siteSettings = globals.getSiteSettings();
 
         const cdnUrl = siteSettings.cdn_url || '';
+        const contentFolderFingerprint = siteSettings.content_folder_fingerprint || '';
 
-        return getObjectStorageImageSrcset(cdnUrl, 'content', path);
+        return getObjectStorageImageSrcset(cdnUrl, 'content', path, contentFolderFingerprint);
     };
 };
 

--- a/helpers/getImageManagerImage.js
+++ b/helpers/getImageManagerImage.js
@@ -6,10 +6,11 @@ const factory = globals => {
         const siteSettings = globals.getSiteSettings();
 
         const cdnUrl = siteSettings.cdn_url || '';
+        const imageManagerFingerprint = siteSettings.image_manager_fingerprint || '';
 
         const options = arguments[arguments.length - 1];
 
-        return getObjectStorageImage(cdnUrl, 'image-manager', path, options);
+        return getObjectStorageImage(cdnUrl, 'image-manager', path, options, imageManagerFingerprint);
     };
 };
 

--- a/helpers/getImageManagerImageSrcset.js
+++ b/helpers/getImageManagerImageSrcset.js
@@ -6,8 +6,9 @@ const factory = globals => {
         const siteSettings = globals.getSiteSettings();
 
         const cdnUrl = siteSettings.cdn_url || '';
+        const imageManagerFingerprint = siteSettings.image_manager_fingerprint || '';
 
-        return getObjectStorageImageSrcset(cdnUrl, 'image-manager', path);
+        return getObjectStorageImageSrcset(cdnUrl, 'image-manager', path, imageManagerFingerprint);
     };
 };
 

--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -1,4 +1,5 @@
 'use strict';
+const URL = require('url').URL;
 
 // Return a function that can be used to translate paths to cdn paths
 module.exports = globals => {
@@ -14,6 +15,7 @@ module.exports = globals => {
         const cdnUrl = siteSettings.cdn_url || '';
         const versionId = siteSettings.theme_version_id;
         const editSessionId = siteSettings.theme_session_id;
+        const contentFolderFingerprint = siteSettings.content_folder_fingerprint || '';
         const cdnSettings = themeSettings.cdn;
 
         if (path instanceof globals.handlebars.SafeString) {
@@ -56,7 +58,11 @@ module.exports = globals => {
             }
 
             if (protocol === 'webdav:') {
-                return [cdnUrl, 'content', path].join('/');
+                let assetUrl = new URL([cdnUrl, 'content', path].join('/'))
+                if (contentFolderFingerprint) {
+                    assetUrl.searchParams.set('t', contentFolderFingerprint);
+                }
+                return assetUrl.toString();
             }
 
             if (cdnSettings) {

--- a/helpers/lib/getObjectStorageImage.js
+++ b/helpers/lib/getObjectStorageImage.js
@@ -2,6 +2,7 @@
 const utils = require('handlebars-utils');
 const common = require('./common');
 const SafeString = require('handlebars').SafeString;
+const URL = require('url').URL;
 
 const srcsets = {
     '80w': '80w',
@@ -14,7 +15,16 @@ const srcsets = {
     '2560w': '2560w',
 };
 
-function getObjectStorageImage(cdnUrl, source, path, options) {
+function generateUrl(cdnUrl, size, source, path, fingerprint) {
+    // Build sized image URL, appending fingerprint if known
+    let assetUrl = new URL(`${cdnUrl}/images/stencil/${size}/${source}/${path}`)
+    if (fingerprint) {
+        assetUrl.searchParams.set('t', contentFolderFingerprint);
+    }
+    return assetUrl.toString()
+}
+
+function getObjectStorageImage(cdnUrl, source, path, options, fingerprint) {
     if (!utils.isString (path) || common.isValidURL(path)) {
         throw new TypeError("Invalid image path - please use a filename or folder path starting from the appropriate folder");
     }
@@ -32,16 +42,16 @@ function getObjectStorageImage(cdnUrl, source, path, options) {
         }
     }
 
-    return new SafeString(`${cdnUrl}/images/stencil/${size}/${source}/${path}`);
+    return new SafeString(generateUrl(cdnUrl, size, source, path, fingerprint));
 }
 
-function getObjectStorageImageSrcset(cdnUrl, source, path) {
+function getObjectStorageImageSrcset(cdnUrl, source, path, fingerprint) {
     if (!utils.isString (path) || common.isValidURL(path)) {
         throw new TypeError("Invalid image path - please use a filename or folder path starting from the appropriate folder");
     }
 
     return new SafeString(Object.keys(srcsets).map(descriptor => {
-        return ([`${cdnUrl}/images/stencil/${srcsets[descriptor]}/${source}/${path} ${descriptor}`].join(' '));
+        return ([`${generateUrl(cdnUrl, srcsets[descriptor], source, path, fingerprint)} ${descriptor}`].join(' '));
     }).join(', '));
 }
 


### PR DESCRIPTION
## What? Why?
If there is an asset fingerprint when using the CDN asset helpers, append it to the resource.

WIP prototype, ignore for now.

## How was it tested?

----

cc @bigcommerce/storefront-team
