### PR TITLE
BCTHEME-276

### DIFF
--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -1,7 +1,34 @@
 'use strict';
 
 const factory = globals => {
-    return function(key, value) {
+    function filterValues(value) {
+        let result = value;
+        try {
+            JSON.parse(value);
+        } catch (e) {
+            if (typeof value === 'string') {
+                result = globals.handlebars.escapeExpression(value);
+            }
+            if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+                result = filterObjectValues(value);
+            }
+            if (Array.isArray(value)) {
+                result = value.map(item => {
+                    return filterValues(item);
+                });
+            }
+        }
+        return result;
+    }
+    function filterObjectValues(obj) {
+        let filteredObject = {};
+        Object.keys(obj).forEach(key => {
+            filteredObject[key] = filterValues(obj[key]);
+        });
+        return filteredObject;
+    }
+
+    return function(key, value, escape) {
         if (typeof value === 'function') {
             return;
         }
@@ -11,8 +38,13 @@ const factory = globals => {
             globals.storage.inject = {};
         }
 
+        // Handlebars supplies a default object if the escape argument isn't provided
+        if (typeof escape === 'object') {
+            escape = false;
+        }
+
         // Store value for later use by jsContext
-        globals.storage.inject[key] = value;
+        globals.storage.inject[key] = escape ? filterValues(value) : value;
     };
 };
 

--- a/spec/helpers/inject.js
+++ b/spec/helpers/inject.js
@@ -8,6 +8,17 @@ describe('inject helper', function() {
     const context = {
         value1: "Big",
         value2: "Commerce",
+        badChars: "&<>\"'`",
+        jsonString: JSON.stringify({"big": "commerce"}),
+        nested: {
+            firstName: "&<>",
+            lastName: "\"'`",
+            addresses: [
+                {
+                    street: "123 &<>\"'` St"
+                }
+            ],
+        },
     };
 
     const runTestCases = testRunner({context});
@@ -20,4 +31,50 @@ describe('inject helper', function() {
             },
         ], done);
     });
+
+    it('should escape strings when escape is set to true', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'filtered' badChars true}}{{jsContext}}",
+                output: '"{\\"filtered\\":\\"&amp;&lt;&gt;&quot;&#x27;&#x60;\\"}"',
+            }
+        ], done);
+    });
+
+    it('should exclude JSON strings from filtering', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'filtered' jsonString}}{{jsContext}}",
+                output: '"{\\"filtered\\":\\"{\\\\\\"big\\\\\\":\\\\\\"commerce\\\\\\"}\\"}"',
+            }
+        ], done);
+    });
+
+    it('should escape strings nested in objects and arrays when escape is set to true', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'filtered' nested true}}{{jsContext}}",
+                output: '"{\\"filtered\\":{\\"firstName\\":\\"&amp;&lt;&gt;\\",\\"lastName\\":\\"&quot;&#x27;&#x60;\\",\\"addresses\\":[{\\"street\\":\\"123 &amp;&lt;&gt;&quot;&#x27;&#x60; St\\"}]}}"',
+            }
+        ], done);
+    });
+
+    it('should not escape characters by default', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'unfiltered' nested.firstName}}{{jsContext}}",
+                output: '"{\\"unfiltered\\":\\"&<>\\"}"',
+            }
+        ], done);
+    })
+
+    it('should not escape characters if escape is set to false', function(done) {
+        runTestCases([
+            {
+                input: "{{inject 'unfiltered' nested.firstName false}}{{jsContext}}",
+                output: '"{\\"unfiltered\\":\\"&<>\\"}"',
+            }
+        ], done);
+    })
+
 });


### PR DESCRIPTION
## What? 
Providing the option to escape values in the inject helper.

## Why?
To help theme developers avoid XSS vulnerabilities when injecting customer supplied data like account fields. When passing true to the inject helper, any values with special characters will be escaped.

The default value is false, to have backwards compatibility with existing themes. This will let devs opt in to escaping injected values.

## How was it tested?
- Created unit tests
- Ran storefront-renderer locally to compare behavior when the 'escape' value for inject is true, false, and not provided

set to false or no argument provided:
![image](https://user-images.githubusercontent.com/16565458/113635157-bd66dc00-9635-11eb-8a27-2dcebfcc87d4.png)

set to true:
![image](https://user-images.githubusercontent.com/16565458/113635209-d1124280-9635-11eb-922c-400181180fc1.png)


----

cc @bigcommerce/storefront-team
