### PR TITLE
MERC-7830 region name localization support

### DIFF
--- a/helpers/region.js
+++ b/helpers/region.js
@@ -3,13 +3,15 @@
 const factory = globals => {
     return function(params) {
         let regionId = params.hash.name;
+        let regionTranslation = params.hash.translation;
         let contentRegions = globals.getContent();
 
         if (!contentRegions) {
             return '';
         }
+        const translationDataAttribute = regionTranslation ? ` data-content-region-translation="${regionTranslation}"` : '';
 
-        const content = `<div data-content-region="${regionId}">${contentRegions[regionId] || ''}</div>`;
+        const content = `<div data-content-region="${regionId}"${translationDataAttribute}>${contentRegions[regionId] || ''}</div>`;
 
         return new globals.handlebars.SafeString(content);
     };

--- a/spec/helpers/region.js
+++ b/spec/helpers/region.js
@@ -29,14 +29,23 @@ describe('Region Helper', () => {
     it('should return an empty container if using empty content context', done => {
         runTestCases([
             {
-                input: '{{region name="banner-bottom"}}',
-                output: '<div data-content-region="banner-bottom"></div>',
+                input: '{{region name="banner-bottom" translation="i18n.RegionName.TestingTranslation"}}',
+                output: '<div data-content-region="banner-bottom" data-content-region-translation="i18n.RegionName.TestingTranslation"></div>',
                 renderer: buildRenderer(),
             },
         ], done);
     });
 
     it('should return an empty container if no matching region on context object', done => {
+        runTestCases([
+            {
+                input: '{{region name="banner-bottom" translation="i18n.RegionName.TestingTranslation"}}',
+                output: '<div data-content-region="banner-bottom" data-content-region-translation="i18n.RegionName.TestingTranslation"></div>',
+            },
+        ], done);
+    });
+
+    it('should return without region translation data attribute if no translation is provided', done => {
         runTestCases([
             {
                 input: '{{region name="banner-bottom"}}',
@@ -48,8 +57,8 @@ describe('Region Helper', () => {
     it('should return Hello World', done => {
         runTestCases([
             {
-                input: '{{region name="banner-top"}}',
-                output: '<div data-content-region="banner-top">hello world</div>',
+                input: '{{region name="banner-top" translation="i18n.RegionName.TestingTranslation"}}',
+                output: '<div data-content-region="banner-top" data-content-region-translation="i18n.RegionName.TestingTranslation">hello world</div>',
             },
         ], done);
     });


### PR DESCRIPTION
## Dependencies
- [x] Paper-handlebars (This PR): PR to allow adding `data-content-region-translation` attribute
- [ ] [Paper](https://github.com/bigcommerce/paper/pull/245): Update to `paper-handlebars` version to support new data attribute
- [ ] [Storefront-renderer](https://github.com/bigcommerce/storefront-renderer/pull/280): Update to `paper` version to support new parsing of region translations 
- [ ] [Stencil-cli](https://github.com/bigcommerce/stencil-cli/pull/731): Update to stencil cli to parse `translation` from theme and generate manifest with new translation data. 
- [ ] [Page builder](https://github.com/bigcommerce/store-design/pull/1101) = Add support to use the correct translation if provided from schemaTranslations. 


## What? Why?
Region name localization support. This PR is to add `content-region-translation` data attribute if translation is provided in the html handlebars from the theme. This will be used to surface the correct translation on the front end (page builder) for a particular region.

<img width="1680" alt="Screen Shot 2021-07-06 at 11 48 34 AM" src="https://user-images.githubusercontent.com/33278039/124653678-71088380-de52-11eb-84f4-d63d36dd9521.png">
<img width="1680" alt="Screen Shot 2021-07-06 at 11 47 45 AM" src="https://user-images.githubusercontent.com/33278039/124653673-6f3ec000-de52-11eb-91f3-e022379c6fcf.png">


## How was it tested?
Steps to test 

(1) Pull down the `storefront-render` [PR](https://github.com/bigcommerce/storefront-renderer/pull/280) and run locally (or can run the container image) 

(2) Pull down `stencil-cli` [PR](https://github.com/bigcommerce/stencil-cli/pull/731) and create theme with `{{{region name="header_bottom" translation="i18n.RegionName.HeaderBottom"}}}` and `i18n.RegionName.HeaderBottom` dummy translation within `schema.json`. **EXAMPLE PROVIDED BELOW**

(3) Change store language to non english language (`chinese` and `french` example provided)

(4) Upload test theme, load page builder and load layers pane to see the correct language.

Example Region + Schema.json

**Region**
`{{{region name="header_bottom" translation="i18n.RegionName.HeaderBottom"}}}`

**Schema.json**
```
  "i18n.RegionName.HeaderBottom": {
    "default": "Header Bottom",
    "en": "Header Bottom",
    "fr-FR": "Bas de l'en-tête",
    "zh": "标题底部",
    "zh-CN": "标题底部"
  }
```


cc @bigcommerce/storefront-team
