### PR TITLE
Release version 4.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 4.4.8
+- Add support for region translations data attribute
+
 ## 4.4.7
 - Replaced URL constructor with url.parse
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
## What? Why?
Release version 4.4.8
Includes changes to support region translations data attribute. 

cc @bigcommerce/storefront-team
