### PR TITLE
STRF-9302 Fix concat helper to have consistency with cdn helper

### DIFF
--- a/helpers/concat.js
+++ b/helpers/concat.js
@@ -1,5 +1,4 @@
 'use strict';
-const SafeString = require('handlebars').SafeString;
 
 /**
  * Concats two values, primarily used as a subhelper
@@ -8,7 +7,7 @@ const SafeString = require('handlebars').SafeString;
  */
 const factory = globals => {
     return function(value, otherValue) {
-        return new SafeString(value + otherValue);
+        return new globals.handlebars.SafeString(value + otherValue);
     };
 };
 

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -16,9 +16,10 @@ describe('cdn helper', function () {
             customcdn2: 'http://cdn.mystore.com',
         }
     };
+    const hbVersion = 'v4';
 
     // Build a test runner that uses a default context
-    const runTestCases = testRunner({context, siteSettings, themeSettings});
+    const runTestCases = testRunner({context, siteSettings, themeSettings, hbVersion});
 
     it('should render the css cdn url', function (done) {
         runTestCases([
@@ -210,6 +211,15 @@ describe('cdn helper', function () {
             {
                 input: '{{cdn (concat "customcdn2:" "/img/image.jpg")}}',
                 output: 'http://cdn.mystore.com/img/image.jpg',
+            },
+        ], done);
+    });
+
+    it('should return a custom CDN asset when using nested concat helper', function (done) {
+        runTestCases([
+            {
+                input: '{{cdn (concat (concat "customcdn2:" "/img/image.jpg") "?test")}}',
+                output: 'http://cdn.mystore.com/img/image.jpg?test',
             },
         ], done);
     });

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -2,10 +2,11 @@ const Crypto = require('crypto');
 const Renderer = require('../index');
 const expect = require('code').expect;
 
-function buildRenderer(siteSettings, themeSettings, templates) {
+function buildRenderer(siteSettings, themeSettings, templates, hbVersion) {
     siteSettings = siteSettings || {};
     themeSettings = themeSettings || {};
-    const renderer = new Renderer(siteSettings, themeSettings);
+    hbVersion = hbVersion || 'v3';
+    const renderer = new Renderer(siteSettings, themeSettings, hbVersion);
 
     // Register templates
     if (typeof templates !== 'undefined') {
@@ -27,14 +28,15 @@ function render(template, context, siteSettings, themeSettings, templates) {
 }
 
 // Return a function that is used to run through a set of test cases using renderString
-function testRunner({context, siteSettings, themeSettings, templates, renderer}) {
+function testRunner({context, siteSettings, themeSettings, templates, renderer, hbVersion}) {
     return (testCases, done) => {
         const promises = testCases.map(testCase => {
             const render = testCase.renderer ||
                            renderer ||
                            buildRenderer(testCase.siteSettings || siteSettings, 
                                          testCase.themeSettings || themeSettings,
-                                         testCase.templates || templates);
+                                         testCase.templates || templates,
+                                         testCase.hbVersion || hbVersion);
 
             return render.renderString(testCase.input, testCase.context || context).then(result => {
                 expect(result).to.be.equal(testCase.output);


### PR DESCRIPTION
## What? Why?

Concat should use global handlebars as it relies on the current theme handlebars version instead of directly importing (which is importing always version 3)

## How was it tested?

e2e and `npm test`

----

cc @bigcommerce/storefront-team
