### PR TITLE
STRF-9215 (fix): SafeString object is taken only from global handlebars object

### DIFF
--- a/helpers/concat.js
+++ b/helpers/concat.js
@@ -1,5 +1,4 @@
 'use strict';
-const SafeString = require('handlebars').SafeString;
 
 /**
  * Concats two values, primarily used as a subhelper
@@ -8,7 +7,7 @@ const SafeString = require('handlebars').SafeString;
  */
 const factory = globals => {
     return function(value, otherValue) {
-        return new SafeString(value + otherValue);
+        return new globals.handlebars.SafeString(value + otherValue);
     };
 };
 

--- a/helpers/encodeHtmlEntities.js
+++ b/helpers/encodeHtmlEntities.js
@@ -2,11 +2,10 @@
 const he = require('he');
 const utils = require('handlebars-utils');
 const common = require('./lib/common.js');
-const SafeString = require('handlebars').SafeString;
 
-const factory = () => {
+const factory = globals => {
     return function(string) {
-        string = common.unwrapIfSafeString(string);
+        string = common.unwrapIfSafeString(globals.handlebars, string);
         if (!utils.isString(string)){
             throw new TypeError("Non-string passed to encodeHtmlEntities");
         }
@@ -33,7 +32,7 @@ const factory = () => {
             }
         }
 
-        return new SafeString(he.encode(string, args));
+        return new globals.handlebars.SafeString(he.encode(string, args));
     };
 };
 

--- a/helpers/getContentImage.js
+++ b/helpers/getContentImage.js
@@ -9,7 +9,7 @@ const factory = globals => {
 
         const options = arguments[arguments.length - 1];
 
-        return getObjectStorageImage(cdnUrl, 'content', path, options);
+        return getObjectStorageImage(globals.handlebars, cdnUrl, 'content', path, options);
     };
 };
 

--- a/helpers/getContentImageSrcset.js
+++ b/helpers/getContentImageSrcset.js
@@ -7,7 +7,7 @@ const factory = globals => {
 
         const cdnUrl = siteSettings.cdn_url || '';
 
-        return getObjectStorageImageSrcset(cdnUrl, 'content', path);
+        return getObjectStorageImageSrcset(globals.handlebars, cdnUrl, 'content', path);
     };
 };
 

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const utils = require('handlebars-utils');
-const SafeString = require('handlebars').SafeString;
 const common = require('./lib/common.js');
 
 const factory = globals => {
@@ -40,7 +39,7 @@ const factory = globals => {
             size = `${Math.min(image.width, width)}x${Math.min(image.height, height)}`
         }
 
-        return new SafeString(image.data.replace('{:size}', size));
+        return new globals.handlebars.SafeString(image.data.replace('{:size}', size));
     };
 };
 

--- a/helpers/getImageManagerImage.js
+++ b/helpers/getImageManagerImage.js
@@ -9,7 +9,7 @@ const factory = globals => {
 
         const options = arguments[arguments.length - 1];
 
-        return getObjectStorageImage(cdnUrl, 'image-manager', path, options);
+        return getObjectStorageImage(globals.handlebars, cdnUrl, 'image-manager', path, options);
     };
 };
 

--- a/helpers/getImageManagerImageSrcset.js
+++ b/helpers/getImageManagerImageSrcset.js
@@ -7,7 +7,7 @@ const factory = globals => {
 
         const cdnUrl = siteSettings.cdn_url || '';
 
-        return getObjectStorageImageSrcset(cdnUrl, 'image-manager', path);
+        return getObjectStorageImageSrcset(globals.handlebars, cdnUrl, 'image-manager', path);
     };
 };
 

--- a/helpers/getImageSrcset.js
+++ b/helpers/getImageSrcset.js
@@ -1,9 +1,8 @@
 'use strict';
 const utils = require('handlebars-utils');
-const SafeString = require('handlebars').SafeString;
 const common = require('./lib/common');
 
-const factory = () => {
+const factory = globals => {
     return function(image, defaultImageUrl) {
         // Regex to test size string is of the form 123x123 or 100w
         const sizeRegex = /(^\d+w$)|(^(\d+?)x(\d+?)$)/;
@@ -61,10 +60,10 @@ const factory = () => {
 
         // If there's only one argument, return a `src` only (also works for `srcset`)
         if (Object.keys(srcsets).length === 1) {
-            return new SafeString((image.data.replace('{:size}', srcsets[Object.keys(srcsets)[0]])));
+            return new globals.handlebars.SafeString((image.data.replace('{:size}', srcsets[Object.keys(srcsets)[0]])));
         }
 
-        return new SafeString(Object.keys(srcsets).reverse().map(descriptor => {
+        return new globals.handlebars.SafeString(Object.keys(srcsets).reverse().map(descriptor => {
             return ([image.data.replace('{:size}', srcsets[descriptor]), descriptor].join(' '));
         }).join(', '));
     };

--- a/helpers/json.js
+++ b/helpers/json.js
@@ -1,9 +1,9 @@
 'use strict';
 const common = require('./lib/common.js');
 
-const factory = () => {
+const factory = globals => {
     return function(data) {
-        data = common.unwrapIfSafeString(data);
+        data = common.unwrapIfSafeString(globals.handlebars, data);
         return JSON.stringify(data);
     };
 };

--- a/helpers/lib/common.js
+++ b/helpers/lib/common.js
@@ -1,6 +1,5 @@
 'use strict';
 const url = require('url');
-const SafeString = require('handlebars').SafeString;
 
 function isValidURL(val) {
     try {
@@ -10,8 +9,8 @@ function isValidURL(val) {
     }
 }
 
-function unwrapIfSafeString(val) {
-    if (val instanceof SafeString) {
+function unwrapIfSafeString(handlebars, val) {
+    if (val instanceof handlebars.SafeString) {
         val = val.toString();
     }
     return val;

--- a/helpers/lib/getObjectStorageImage.js
+++ b/helpers/lib/getObjectStorageImage.js
@@ -1,7 +1,6 @@
 'use strict';
 const utils = require('handlebars-utils');
 const common = require('./common');
-const SafeString = require('handlebars').SafeString;
 
 const srcsets = {
     '80w': '80w',
@@ -14,7 +13,7 @@ const srcsets = {
     '2560w': '2560w',
 };
 
-function getObjectStorageImage(cdnUrl, source, path, options) {
+function getObjectStorageImage(handlebars, cdnUrl, source, path, options) {
     if (!utils.isString (path) || common.isValidURL(path)) {
         throw new TypeError("Invalid image path - please use a filename or folder path starting from the appropriate folder");
     }
@@ -32,15 +31,15 @@ function getObjectStorageImage(cdnUrl, source, path, options) {
         }
     }
 
-    return new SafeString(`${cdnUrl}/images/stencil/${size}/${source}/${path}`);
+    return new handlebars.SafeString(`${cdnUrl}/images/stencil/${size}/${source}/${path}`);
 }
 
-function getObjectStorageImageSrcset(cdnUrl, source, path) {
+function getObjectStorageImageSrcset(handlebars, cdnUrl, source, path) {
     if (!utils.isString (path) || common.isValidURL(path)) {
         throw new TypeError("Invalid image path - please use a filename or folder path starting from the appropriate folder");
     }
 
-    return new SafeString(Object.keys(srcsets).map(descriptor => {
+    return new handlebars.SafeString(Object.keys(srcsets).map(descriptor => {
         return ([`${cdnUrl}/images/stencil/${srcsets[descriptor]}/${source}/${path} ${descriptor}`].join(' '));
     }).join(', '));
 }

--- a/helpers/replace.js
+++ b/helpers/replace.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('./lib/common.js');
 
-const factory = () => {
+const factory = globals => {
     return function(needle, haystack) {
-        needle = common.unwrapIfSafeString(needle);
-        haystack = common.unwrapIfSafeString(haystack);
+        needle = common.unwrapIfSafeString(globals.handlebars, needle);
+        haystack = common.unwrapIfSafeString(globals.handlebars, haystack);
         const options = arguments[arguments.length - 1];
 
         if (typeof needle !== 'string') {

--- a/helpers/setURLQueryParam.js
+++ b/helpers/setURLQueryParam.js
@@ -1,13 +1,12 @@
 'use strict';
 const utils = require('handlebars-utils');
 const common = require('./lib/common.js');
-const SafeString = require('handlebars').SafeString;
 
-const factory = () => {
+const factory = globals => {
     return function(string, key, value) {
-        string = common.unwrapIfSafeString(string);
-        key = common.unwrapIfSafeString(key);
-        value = common.unwrapIfSafeString(value);
+        string = common.unwrapIfSafeString(globals.handlebars, string);
+        key = common.unwrapIfSafeString(globals.handlebars, key);
+        value = common.unwrapIfSafeString(globals.handlebars, value);
         if (!utils.isString(string) || !common.isValidURL(string)){
             throw new TypeError("Invalid URL passed to setURLQueryParam");
         } else if (!utils.isString(key)){
@@ -20,7 +19,7 @@ const factory = () => {
 
         url.searchParams.set(encodeURIComponent(key), encodeURIComponent(value));
 
-        return new SafeString(url.toString());
+        return new globals.handlebars.SafeString(url.toString());
     };
 };
 

--- a/helpers/stripQuerystring.js
+++ b/helpers/stripQuerystring.js
@@ -2,9 +2,9 @@
 const utils = require('handlebars-utils');
 const common = require('./lib/common.js');
 
-const factory = () => {
+const factory = globals => {
     return function(url) {
-        url = common.unwrapIfSafeString(url);
+        url = common.unwrapIfSafeString(globals.handlebars, url);
         if (utils.isString(url)) {
             return url.split('?')[0];
         }

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -5,7 +5,9 @@ const Lab = require('lab'),
       testRunner = require('../spec-helpers').testRunner;
 
 describe('cdn helper', function () {
-    const context = {};
+    const context = {
+        brand: 'visa',
+    };
     const siteSettings = {
         cdn_url: 'https://cdn.bcapp/3dsf74g',
         theme_version_id: '123',
@@ -236,6 +238,10 @@ describe('cdn helper', function () {
                 output: '/assets/cdn/customcdn2/img/image.jpg',
                 siteSettings: {},
             },
+            {
+                input: "{{cdn (concat (concat 'img/payment-methods/' brand) '.svg')}}",
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/img/payment-methods/visa.svg',
+            }
         ], done);
     });
 


### PR DESCRIPTION
## What? Why?

Currently SafeString object is being imported from handlebars library directly in some places and from `globals.handlebars` in another. 
The first one import shouldn't be used as it imports always only v3, while `globals.handlebars` relies on the handlebars version that was used during initialization.


## How was it tested?

_npm test_

e2e on storefront

----

cc @bigcommerce/storefront-team
