### PR TITLE
Release 4.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.4.9
+- Fix concat helper to have consistency with cdn helper ([#144](https://github.com/bigcommerce/paper-handlebars/pull/144))
+- Release stencil paper handlebars through github release ([#145](https://github.com/bigcommerce/paper-handlebars/pull/145))
+- SafeString object is taken only from global handlebars object ([#146](https://github.com/bigcommerce/paper-handlebars/pull/146))
+
 ## 4.4.8
 - Add support for region translations data attribute
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.4.8",
+  "version": "4.4.9",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Release 4.4.9

- Fix concat helper to have consistency with cdn helper ([#144](https://github.com/bigcommerce/paper-handlebars/pull/144))
- Release stencil paper handlebars through github release ([#145](https://github.com/bigcommerce/paper-handlebars/pull/145))
- SafeString object is taken only from global handlebars object ([#146](https://github.com/bigcommerce/paper-handlebars/pull/146))


----

cc @bigcommerce/storefront-team
