### PR TITLE
STRF-9215 (fix): Fix Github action on Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '10.x'
-      - run: npm ci
+      - run: npm i
       # Setup .npmrc file to publish to npm registry
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
       - run: npm publish


### PR DESCRIPTION
## What? Why?

Fix Github action on Release

Replace` npm ci ` with `npm i`.

`npm ci` commonly used in automated environments: tests, deployments, etc and it's not updating package-lock.json
But the thing is, that this is a dependent library and we decided not to include package-lock.json in repo, so this command can't be used in Github Actions. 

----

cc @bigcommerce/storefront-team
