### PR TITLE
Release 4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 4.5.1
+- Support floats for assignVar/getVar ([#152](https://github.com/bigcommerce/paper-handlebars/pull/152))
+- Stop testing on node 10, start testing on node 14, release on 14 ([#151](https://github.com/bigcommerce/paper-handlebars/pull/151))
+
 ## 4.5.0
 - Add getImageSrcset1x2x helper ([#149](https://github.com/bigcommerce/paper-handlebars/pull/149))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
## 4.5.1
- Support floats for assignVar/getVar ([#152](https://github.com/bigcommerce/paper-handlebars/pull/152))
- Stop testing on node 10, start testing on node 14, release on 14 ([#151](https://github.com/bigcommerce/paper-handlebars/pull/151))


----

cc @bigcommerce/storefront-team
