### PR TITLE
String Replace Helper with More Options

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -44,6 +44,7 @@ const helpersList = [
     'setURLQueryParam',
     'snippets',
     'stripQuerystring',
+    'strReplace',
     'stylesheet',
     'thirdParty',
     'toLowerCase',

--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -1,22 +1,40 @@
 'use strict';
 
 const factory = () => {
-    return function(string, substr, newSubstr, token) {
-        if (typeof string !== 'string' || typeof substr !== 'string' || typeof newSubstr !== 'string') {
+    return function(str, substr, newSubstr, iteration) {
+        if (typeof str !== 'string' || typeof substr !== 'string' || typeof newSubstr !== 'string') {
             return 'Invalid Input';
         }
 
-        if (token && typeof token === 'string') {
-            return string.replace(new RegExp(escapeRegex(substr), token), newSubstr);
-        } else {
-            return string.replace(new RegExp(escapeRegex(substr), 'g'), newSubstr);
+        if (typeof iteration !== 'number') {
+            return str.replace(new RegExp(escapeRegex(substr), 'g'), newSubstr);
         }
 
+        const occurrence = getOccurrences(str, substr);
+
+        if (iteration > 0 && occurrence > 0) {
+            if (iteration >= occurrence) {
+                return str.replace(new RegExp(escapeRegex(substr), 'g'), newSubstr);
+            } else {
+                let result = str;
+                for (let i = 0; i < iteration; i++) {
+                    result = result.replace(substr, newSubstr);
+                }
+                return result;
+            }
+        } else {
+            return str;
+        }
     };
 };
 
 function escapeRegex(string) {
     return string.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+function getOccurrences(str, substr) {
+    const matches = str.match(new RegExp(escapeRegex(substr),'g'));
+    return matches ? matches.length : 0;
 }
 
 module.exports = [{

--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -1,9 +1,20 @@
 'use strict';
+const common = require('./lib/common.js');
+const utils = require('handlebars-utils');
 
-const factory = () => {
+const factory = globals => {
     return function(str, substr, newSubstr, iteration) {
-        if (typeof str !== 'string' || typeof substr !== 'string' || typeof newSubstr !== 'string') {
-            return 'Invalid Input';
+        str = common.unwrapIfSafeString(globals.handlebars, str);
+        substr = common.unwrapIfSafeString(globals.handlebars, substr);
+        newSubstr = common.unwrapIfSafeString(globals.handlebars, newSubstr);
+        iteration = common.unwrapIfSafeString(globals.handlebars, iteration);
+
+        if (!utils.isString(str)){
+            throw new TypeError("Invalid query parameter string passed to strReplace");
+        } else if (!utils.isString(substr)){
+            throw new TypeError("Invalid query paramter substring passed to strReplace");
+        } else if(!utils.isString(newSubstr)) {
+            throw new TypeError("Invalid query parameter new substring passed to strReplace");
         }
 
         if (typeof iteration !== 'number') {

--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const factory = () => {
+    return function(string, substr, newSubstr, token) {
+        if (typeof string !== 'string' || typeof substr !== 'string' || typeof newSubstr !== 'string') {
+            return 'Invalid Input';
+        }
+
+        if (token && typeof token === 'string') {
+            return string.replace(new RegExp(escapeRegex(substr), token), newSubstr);
+        } else {
+            return string.replace(new RegExp(escapeRegex(substr), 'g'), newSubstr);
+        }
+
+    };
+};
+
+function escapeRegex(string) {
+    return string.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+module.exports = [{
+    name: 'strReplace',
+    factory: factory,
+}];

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -63,6 +63,7 @@ describe('helper registration', () => {
             'setURLQueryParam',
             'snippet',
             'stripQuerystring',
+            'strReplace',
             'stylesheet',
             'after',
             'arrayify',

--- a/spec/helpers/strReplace.js
+++ b/spec/helpers/strReplace.js
@@ -1,0 +1,51 @@
+const Lab = require('lab'),
+      lab = exports.lab = Lab.script(),
+      describe = lab.experiment,
+      it = lab.it,
+      testRunner = require('../spec-helpers').testRunner;
+
+describe('strReplace helper', function() {
+    const context = {
+        string: "My name is Albe Albe Albe",
+        substr: "Albe",
+        newSubstr: "Alex",
+        object: {}
+    };
+
+    const runTestCases = testRunner({context});
+
+    it('should replace all by default', function(done) {
+        runTestCases([
+            {
+                input: '{{strReplace string substr newSubstr}}',
+                output: 'My name is Alex Alex Alex',
+            },
+            {
+                input: '{{strReplace "Your name is none" "none" "Bob"}}',
+                output: 'Your name is Bob',
+            },
+        ], done);
+    });
+
+    it('should replace one if given token', function(done) {
+        runTestCases([
+            {
+                input: '{{strReplace string substr newSubstr "i"}}',
+                output: 'My name is Alex Albe Albe',
+            },
+        ], done);
+    });
+
+    it('should only handle string', function(done) {
+         runTestCases([
+            {
+                input: '{{strReplace 5 5 5}}',
+                output: 'Invalid Input',
+            },
+            {
+                input: '{{strReplace object "none" "Bob"}}',
+                output: 'Invalid Input',
+            },
+        ], done);
+    });
+});

--- a/spec/helpers/strReplace.js
+++ b/spec/helpers/strReplace.js
@@ -27,11 +27,27 @@ describe('strReplace helper', function() {
         ], done);
     });
 
-    it('should replace one if given token', function(done) {
+    it('should replace multiple if given quantity', function(done) {
         runTestCases([
             {
-                input: '{{strReplace string substr newSubstr "i"}}',
-                output: 'My name is Alex Albe Albe',
+                input: '{{strReplace string substr newSubstr -5}}',
+                output: 'My name is Albe Albe Albe',
+            },
+            {
+                input: '{{strReplace string substr newSubstr 0}}',
+                output: 'My name is Albe Albe Albe',
+            },
+            {
+                input: '{{strReplace string substr newSubstr 2}}',
+                output: 'My name is Alex Alex Albe',
+            },
+            {
+                input: '{{strReplace string substr newSubstr 4}}',
+                output: 'My name is Alex Alex Alex',
+            },
+            {
+                input: '{{strReplace string substr newSubstr 100}}',
+                output: 'My name is Alex Alex Alex',
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?

This is an inline string replacement helper that gives the user more control in how many occurrences of the substring to be replaced. 

## How was it tested?

It was tested by giving several test cases including inputs that are out of bound. 

`{{strReplace string substr newSubstr}}` would replace all substring by default

`{{strReplace string substr newSubstr count}}` would replace count of occurrences.

Invalid string input would return invalid. 
Invalid count would return original string and extra count (count > occurrences) would regard as replace all. 

Added parameter unwrap function to work with other helpers.
Added throw TypeError instead of return Invalid String.

----

cc @bigcommerce/storefront-team
