### PR TITLE
Release 4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 4.5.2
+- Add log level variable to control log helper ([#158](https://github.com/bigcommerce/paper-handlebars/pull/158))
+
 ## 4.5.1
 - Support floats for assignVar/getVar ([#152](https://github.com/bigcommerce/paper-handlebars/pull/152))
 - Stop testing on node 10, start testing on node 14, release on 14 ([#151](https://github.com/bigcommerce/paper-handlebars/pull/151))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- Add log level variable to control log helper ([#158](https://github.com/bigcommerce/paper-handlebars/pull/158))


cc @bigcommerce/storefront-team
