### PR TITLE
Do not return values from incrementVar and decrementVar helpers

### DIFF
--- a/helpers/decrementVar.js
+++ b/helpers/decrementVar.js
@@ -24,9 +24,6 @@ const factory = globals => {
             // Initialize or re-initialize value
             globals.storage.variables[key] = 0;
         }
-
-        // Return current value
-        return globals.storage.variables[key];
     };
 };
 

--- a/helpers/incrementVar.js
+++ b/helpers/incrementVar.js
@@ -24,9 +24,6 @@ const factory = globals => {
             // Initialize or re-initialize value
             globals.storage.variables[key] = 0;
         }
-
-        // Return current value
-        return globals.storage.variables[key];
     };
 };
 


### PR DESCRIPTION
## What? Why?
The issue was first reported in issue #111.

The incrementVar and decrementVar helpers currently return the value of the handlebars variable, which results in the value being outputted to html.

## How was it tested?
I removed the return lines on my local copy of stencil-cli/paper-handlebars, and the helpers then worked as expected without printing the variable values to html.

I'm not very familiar with the paper-handlebars source, but I can see that other helper functions like assignVar do not return values.

----

cc @bigcommerce/storefront-team @bookernath
