### PR TITLE
feat: STRF-9707 Improve money helper to support input params

### DIFF
--- a/helpers/money.js
+++ b/helpers/money.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * Format numbers
  *
@@ -17,19 +15,32 @@ function numberFormat(value, n, s, c) {
 }
 
 const factory = globals => {
-    return function(value) {
+    return function(...args) {
         const siteSettings = globals.getSiteSettings();
         const money = siteSettings.money;
 
-        if (!_.isNumber(value)) {
-            return '';
+        // remove options hash object
+        args.pop();
+
+        let value = args[0];
+
+        if (isNaN(value)) {
+            throw new TypeError("money helper accepts only Number's as first parameter");
         }
+
+        const decimalPlaces = args[1] || money.decimal_places;
+
+        if (isNaN(decimalPlaces)) {
+            throw new TypeError("money helper accepts only Number's for decimal places");
+        }
+        const thousandsToken = args[2] || money.thousands_token;
+        const decimalToken = args[3] || money.decimal_token;
 
         value = numberFormat(
             value,
-            money.decimal_places,
-            money.thousands_token,
-            money.decimal_token
+            decimalPlaces,
+            thousandsToken,
+            decimalToken
         );
 
         return money.currency_location === 'left'

--- a/spec/helpers/money.js
+++ b/spec/helpers/money.js
@@ -1,0 +1,72 @@
+const Lab = require('lab');
+const { expect } = require('code');
+const lab = exports.lab = Lab.script();
+const describe = lab.experiment;
+const it = lab.it;
+const { testRunner, renderString } = require('../spec-helpers');
+
+describe('money helper', function() {
+    const context = {
+        price: 1234.56,
+    };
+    const siteSettings = {
+        money: {
+            currency_location: "left",
+            currency_token: "$",
+            decimal_places: 2,
+            thousands_token: ',',
+            decimal_token: '.',
+        }
+    };
+
+
+    it('should correctly set money value from money site settings', function(done) {
+        const runTestCases = testRunner({context, siteSettings});
+        runTestCases([
+            {
+                input: '{{money price}}',
+                output: '$ 1,234.56',
+            },
+            {
+                input: '{{money 12.34}}',
+                output: '$ 12.34',
+            },
+        ], done);
+    });
+
+    it('should read money site settings from input parameters', function(done) {
+        const runTestCases = testRunner({context, siteSettings});
+        runTestCases([
+            {
+                input: '{{money price 1}}',
+                output: '$ 1,234.6',
+            },
+            {
+                input: '{{money price 3}}',
+                output: '$ 1,234.560',
+            },
+            {
+                input: '{{money price 2 "."}}',
+                output: '$ 1.234.56',
+            },
+            {
+                input: '{{money price 2 "," ","}}',
+                output: '$ 1,234,56',
+            },
+        ], done);
+    });
+
+    it('should throw an exception if the price value parameter has an invalid type', function(done) {
+        renderString('{{money "hello"}}').catch(err => {
+            expect(err.message).to.equal("money helper accepts only Number's as first parameter");
+            done();
+        });
+    });
+
+    it('should throw an exception if the decimal places parameter has an invalid type', function(done) {
+        renderString('{{money 1.2 "hello"}}').catch(err => {
+            expect(err.message).to.equal("money helper accepts only Number's for decimal places");
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## What? Why?

Improved money helper to support input params according to the docs

## How was it tested?

`npm test`, e2e

----

cc @bigcommerce/storefront-team
