### PR TITLE
chore: release 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 4.6.0
+- fix: STRF-9835 Reduce proto usage ([#167](https://github.com/bigcommerce/paper-handlebars/pull/167))
+
 ## 4.5.5
 - feat: STRF-9707 Improve money helper to support input params ([#164](https://github.com/bigcommerce/paper-handlebars/pull/164))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "4.5.5",
+  "version": "4.6.0",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION

- fix: STRF-9835 Reduce proto usage ([#167](https://github.com/bigcommerce/paper-handlebars/pull/167))



cc @bigcommerce/storefront-team
