### PR TITLE
feat: STRF-9791 drop node 12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12.x, 14.x]
+        node: [14.x]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What? Why?

Removing Node 12 from supported versions list

----

cc @bigcommerce/storefront-team
