### PR TITLE
fix: STRF 9873 make `get` etc. compatible with `concat` return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Fix replacement `get` and `option` helpers for backwards-compatibility ([#173](https://github.com/bigcommerce/paper-handlebars/pull/173))
+- `get` now fully supports property paths constructed using `concat`
+
 ## 5.0.1
 - fix: STRF-9873 use modified implementations of `get`, `getObject`, `moment`, `option` 3p helpers ([#171](https://github.com/bigcommerce/paper-handlebars/pull/171))
 

--- a/helpers/get.js
+++ b/helpers/get.js
@@ -8,7 +8,7 @@ const { getValue } = require('./lib/common');
  * Get a value from the given context object. Property paths (`a.b.c`) may be used
  * to get nested properties.
  */
-const factory = () => {
+const factory = (globals) => {
     return function (path, context) {
         let options = arguments[arguments.length - 1];
 
@@ -17,7 +17,7 @@ const factory = () => {
             context = {};
         }
 
-        let value = getValue(context, path);
+        let value = getValue(globals, context, path);
         if (options && options.fn) {
             return value ? options.fn(value) : options.inverse(context);
         }

--- a/helpers/getObject.js
+++ b/helpers/getObject.js
@@ -9,7 +9,7 @@ const { getValue } = require('./lib/common');
  * Get an object or array containing a value from the given context object.
  * Property paths (`a.b.c`) may be used to get nested properties.
  */
-const factory = () => {
+const factory = (globals) => {
     return function (path, context) {
         // use an empty context if none was given
         // (expect 3 args: `path`, `context`, and the `options` object 
@@ -25,7 +25,9 @@ const factory = () => {
 
         path = String(path);
 
-        let value = getValue(context, path);
+        const parts = path.split(/[[.\]]/).filter(Boolean);
+
+        let value = getValue(globals, context, parts);
 
         // for backwards compatibility: `get-object` returns on empty object instead of
         // getting props with 'false' values (not just undefined)
@@ -34,7 +36,6 @@ const factory = () => {
         }
 
         // return an array if the final path part is numeric to mimic behavior of `get-object`
-        const parts = path.split(/[[.\]]/).filter(Boolean);
         const last = parts[parts.length - 1];
         if (Number.isFinite(Number(last))) {
             return [ value ];

--- a/helpers/lib/common.js
+++ b/helpers/lib/common.js
@@ -10,19 +10,25 @@ function isValidURL(val) {
 }
 
 /*
- * Based on https://github.com/jonschlinkert/get-value/blob/3.0.1/index.js, but
- * with configurability that was not used in handlebars-helpers removed.
+ * Based on https://github.com/jonschlinkert/get-value/blob/2.0.6/index.js with some enhancements.
+ * 
+ * - Performs "hasOwnProperty" checks for safety.
+ * - Now accepts Handlebars.SafeString paths.
  */
-function getValue(object, path) {
+function getValue(globals, object, path) {
     let parts;
+
+    // unwrap Handlebars.SafeString for compatibility with `concat` etc.
+    path = unwrapIfSafeString(globals.handlebars, path);
+
     // accept array or string for backwards compatibility
-    if (!Array.isArray(path)) {
-        if (typeof path !== 'string') {
-            return object;
-        }
-        parts = path.split(/[[.\]]/).filter(Boolean);
+    if (typeof path === 'string') {
+        parts = path.split('.');
+    } else if (Array.isArray(path)) {
+        parts = path;
     } else {
-        parts = path.map(v => String(v));
+        let key = String(path);
+        return Object.prototype.hasOwnProperty.call(object, key) ? object[key] : undefined;
     }
 
     let result = object;

--- a/helpers/option.js
+++ b/helpers/option.js
@@ -9,7 +9,7 @@ const { getValue } = require('./lib/common');
  * Get a value from the options object. Property paths (`a.b.c`) may be used
  * to get nested properties.
  */
-const factory = () => {
+const factory = (globals) => {
     return function (path, locals) {
         // preserve `option` behavior with missing args while ensuring the correct
         // options object is used
@@ -23,7 +23,7 @@ const factory = () => {
 
         let opts = util.options(this, locals, options);
 
-        return getValue(opts, path);
+        return getValue(globals, opts, path);
     };
 };
 

--- a/spec/helpers/get.js
+++ b/spec/helpers/get.js
@@ -7,7 +7,9 @@ const Lab = require('lab'),
 describe('get helper', function () {
     const context = {
         array: [1, 2, 3, 4, 5],
-        options: { a: { b: { c: 'd' } } }
+        options: { a: { b: { c: 'd' } } },
+        aa: 'a',
+        ab: 'b',
     };
 
     const runTestCases = testRunner({ context });
@@ -27,6 +29,19 @@ describe('get helper', function () {
             {
                 input: `{{get "x" this}}`,
                 output: ``,
+            }
+        ], done);
+    });
+
+    it('accepts SafeString paths', (done) => {
+        runTestCases([
+            {
+                input: `{{get (concat 'a' 'a') this}}`,
+                output: `a`,
+            },
+            {
+                input: `{{get (concat 'a' 'b') this}}`,
+                output: `b`,
             }
         ], done);
     });

--- a/spec/helpers/getObject.js
+++ b/spec/helpers/getObject.js
@@ -12,7 +12,9 @@ describe('getObject helper', function () {
                     c: 'd'
                 },
                 array: [1, 2, 3, 4, 5]
-            }
+            },
+            aa: 'a',
+            ab: 'b',
         }
     };
 
@@ -38,6 +40,19 @@ describe('getObject helper', function () {
                 input: `{{#with (getObject "x" obj)}}{{x}}{{/with}}`,
                 output: ``,
             },
+        ], done);
+    });
+
+    it('accepts SafeString paths', (done) => {
+        runTestCases([
+            {
+                input: `{{get 'aa' (getObject (concat 'a' 'a') obj)}}`,
+                output: `a`,
+            },
+            {
+                input: `{{get 'ab' (getObject (concat 'a' 'b') obj)}}`,
+                output: `b`,
+            }
         ], done);
     });
 });

--- a/spec/helpers/lib/common.js
+++ b/spec/helpers/lib/common.js
@@ -5,9 +5,11 @@ const Lab = require('lab'),
       lab = exports.lab = Lab.script(),
       describe = lab.experiment,
       it = lab.it;
+const Handlebars = require('handlebars');
 
 describe('common utils', function () {
     describe('getValue', function () {
+        const globals = {handlebars: Handlebars};
         const obj = {
             a: {
                 a: [{x: 'a'}, {y: 'b'}],
@@ -21,63 +23,70 @@ describe('common utils', function () {
             b: [2, 3, 5, 7, 11, 13, 17, 19],
             c: 3,
             d: false,
+            '42': 42,
         };
         obj.__proto__ = {x: 'yz'};
 
         it('should get a value from an object', (done) => {
-            expect(getValue(obj, 'c')).to.equal(3);
-            expect(getValue(obj, 'd')).to.equal(false);
+            expect(getValue(globals, obj, 'c')).to.equal(3);
+            expect(getValue(globals, obj, 'd')).to.equal(false);
             done();
         });
 
         it('should get nested values', (done) => {
-            expect(getValue(obj, 'a.b.b.a')).to.equal(1);
-            expect(getValue(obj, ['a', 'b', 'b', 'a'])).to.equal(1);
+            expect(getValue(globals, obj, 'a.b.b.a')).to.equal(1);
+            expect(getValue(globals, obj, ['a', 'b', 'b', 'a'])).to.equal(1);
             done();
         });
 
         it('should get nested values from arrays', (done) => {
-            expect(getValue(obj, 'b.0')).to.equal(2);
-            expect(getValue(obj, 'a.c.5')).to.equal(8);
+            expect(getValue(globals, obj, 'b.0')).to.equal(2);
+            expect(getValue(globals, obj, 'a.c.5')).to.equal(8);
             done();
         });
 
         it('should get nested values from objects in arrays', (done) => {
-            expect(getValue(obj, 'a.a.1.y')).to.equal('b');
+            expect(getValue(globals, obj, 'a.a.1.y')).to.equal('b');
             done();
         });
 
-        it('should return the whole object if path is not a string or array', (done) => {
-            expect(getValue(obj, {})).to.equal(obj);
-            expect(getValue(obj)).to.equal(obj);
+        it('should return obj[String(path)] or undefined if path is not a string or array', (done) => {
+            expect(getValue(globals, obj, {})).to.equal(undefined);
+            expect(getValue(globals, obj)).to.equal(undefined);
+            expect(getValue(globals, obj, 42)).to.equal(42);
             done();
         });
 
         it('should return the whole object if path is empty', (done) => {
-            expect(getValue(obj, '')).to.equal(obj);
-            expect(getValue(obj, [])).to.equal(obj);
+            expect(getValue(globals, obj, [])).to.equal(obj);
+            done();
+        });
+
+        it('should get empty string key if path is \'\'', (done) => {
+            expect(getValue(globals, obj, '')).to.equal(undefined);
+            expect(getValue(globals, {'': 0}, '')).to.equal(0);
             done();
         });
 
         it('should return undefined if prop does not exist', (done) => {
-            expect(getValue(obj, 'a.a.a.a')).to.equal(undefined);
-            expect(getValue(obj, 'a.c.23')).to.equal(undefined);
-            expect(getValue(obj, 'ab')).to.equal(undefined);
-            expect(getValue(obj, 'nonexistent')).to.equal(undefined);
+            expect(getValue(globals, obj, 'a.a.a.a')).to.equal(undefined);
+            expect(getValue(globals, obj, 'a.c.23')).to.equal(undefined);
+            expect(getValue(globals, obj, 'ab')).to.equal(undefined);
+            expect(getValue(globals, obj, 'nonexistent')).to.equal(undefined);
             done();
         });
 
         it('should treat backslash-escaped . characters as part of a prop name', (done) => {
             const data = {'a.b': {'c.d.e': 42, z: 'xyz'}};
 
-            expect(getValue(data, 'a\\.b.z')).to.equal('xyz');
-            expect(getValue(data, 'a\\.b.c\\.d\\.e')).to.equal(42);
+            expect(getValue(globals, data, 'a\\.b.z')).to.equal('xyz');
+            expect(getValue(globals, data, 'a\\.b.c\\.d\\.e')).to.equal(42);
             done()
         });
 
         it('should not access inherited props', (done) => {
-            expect(getValue(obj, 'x')).to.equal(undefined);
-            expect(getValue(obj, 'a.constructor')).to.equal(undefined);
+            expect(getValue(globals, obj, 'x')).to.equal(undefined);
+            expect(getValue(globals, obj, 'a.constructor')).to.equal(undefined);
             done();
         });
     });

--- a/spec/helpers/option.js
+++ b/spec/helpers/option.js
@@ -30,4 +30,13 @@ describe('option helper', function () {
             },
         ], done);
     });
+
+    it('accepts SafeString paths', (done) => {
+        runTestCases([
+            {
+                input: `{{option (concat 'a.b.' 'c')}}`,
+                output: `d`,
+            },
+        ], done);
+    });
 });


### PR DESCRIPTION
## What? Why?

[#171](https://github.com/bigcommerce/paper-handlebars/pull/171) inadvertently broke an edge case where the `concat` helper is used to dynamically generate property paths.

With the original `get` and `option` helpers, this only worked with top-level properties (not nested properties) due to an implicit `toString` conversion [here](https://github.com/jonschlinkert/get-value/blob/2.0.6/index.js#L22). This PR modifies those helpers to accept both top-level and nested property paths generated by `concat`.

_Edit: During testing & review, I noticed that the old `get` helper would retrieve empty string keys (`get({'': 0}, '')` would return `0`) and have made changes to match that behavior._

## How was it tested?

Unit tests have been added to cover cases where `concat` is used to generate property paths for helpers modified in [#171](https://github.com/bigcommerce/paper-handlebars/pull/171).

----

cc @bigcommerce/storefront-team
