### PR TITLE
patch for helper-date 0.2.3 compatibility

### DIFF
--- a/helpers/moment.js
+++ b/helpers/moment.js
@@ -14,15 +14,14 @@ const factory = () => {
     return function (str, pattern) {
         // always use the Handlebars-generated options object
         let options = arguments[arguments.length - 1];
-        if (arguments.length < 3) {
-            pattern = null;
-        }
-        if (arguments.length < 2) {
-            str = null;
-        }
+
+        // Ideally we'd check how many args were passed and set `str` and `pattern` to
+        // null if they weren't explicitly provided. However, doing so could break
+        // backwards compatibility since we previously depended on helper-date@0.2.3.
 
         // if no args are passed, return a formatted date
-        if (str === null && pattern === null) {
+        /* eslint no-eq-null: ["off"] */
+        if (str == null && pattern == null) {
             moment.locale('en');
             return moment().format('MMMM DD, YYYY');
         }

--- a/spec/helpers/moment.js
+++ b/spec/helpers/moment.js
@@ -3,6 +3,7 @@ const Lab = require('lab'),
     describe = lab.experiment,
     it = lab.it,
     testRunner = require('../spec-helpers').testRunner;
+const moment = require('moment');
 
 describe('moment helper', function () {
     const runTestCases = testRunner({});
@@ -13,7 +14,28 @@ describe('moment helper', function () {
             {
                 input: `{{moment "1 year ago" "YYYY"}}`,
                 output: `${now.getFullYear() - 1}`,
+            }
+        ], done);
+    });
+
+    it('is backwards compatible with helper-date 0.2.3 null-argument behavior', (done) => {
+        runTestCases([
+            {
+                input: `{{moment format="YYYY"}}`,
+                output: moment().format('YYYY'),
             },
+            {
+                input: `{{moment null null}}`,
+                output: moment().format('MMMM DD, YYYY'),
+            },
+            {
+                input: `{{moment undefined undefined}}`,
+                output: moment().format('MMMM DD, YYYY'),
+            },
+            {
+                input: `{{moment "now" format="YYYY"}}`,
+                output: `Invalid date`,
+            }
         ], done);
     });
 


### PR DESCRIPTION
## What? Why?

Restore some previous behavior of the `moment` helper.

## How was it tested?

Unit tests have been added for the known affected use cases.

----

cc @bigcommerce/storefront-team
