### PR TITLE
fix: add check for undefined/null before calling Object.keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- bugfix for edge case affecting `get`, `getObject`, and `option`
+
 ## 5.0.5
 - setup to replace `get` & `getObject` helpers ([#183](https://github.com/bigcommerce/paper-handlebars/pull/183))
 ## 5.0.4

--- a/helpers/lib/common.js
+++ b/helpers/lib/common.js
@@ -39,6 +39,9 @@ function getValue(globals, object, path) {
     let result = object;
     let prefix = '';
     for (let key of parts) {
+        if (result === undefined || result === null) {
+            return undefined;
+        }
         // preserve handling of trailing backslashes for backwards compatibility
         if (key.slice(-1) === '\\') {
             prefix = prefix + key.slice(0, -1) + '.';

--- a/spec/helpers/get.js
+++ b/spec/helpers/get.js
@@ -23,16 +23,15 @@ describe('get helper', function () {
         ], done);
     });
 
-    // uncomment when 3rd-party version is replaced
-    // it('does not access prototype properties', (done) => {
-    //     context.__proto__ = {x: 'yz'};
-    //     runTestCases([
-    //         {
-    //             input: `{{get "x" this}}`,
-    //             output: ``,
-    //         }
-    //     ], done);
-    // });
+    it('does not access prototype properties', (done) => {
+        context.__proto__ = {x: 'yz'};
+        runTestCases([
+            {
+                input: `{{get "x" this}}`,
+                output: ``,
+            }
+        ], done);
+    });
 
     it('accepts SafeString paths', (done) => {
         runTestCases([
@@ -44,11 +43,10 @@ describe('get helper', function () {
                 input: `{{get (concat 'a' 'b') this}}`,
                 output: `b`,
             },
-            // uncomment when 3rd-party version is replaced
-            // {
-            //     input: `{{get (concat 'options.a' '.b.c') this}}`,
-            //     output: `d`,
-            // }
+            {
+                input: `{{get (concat 'options.a' '.b.c') this}}`,
+                output: `d`,
+            }
         ], done);
     });
 
@@ -86,6 +84,19 @@ describe('get helper', function () {
             },
             {
                 input: `{{get 'a' null}}`,
+                output: ``,
+            }
+        ], done);
+    });
+
+    it('returns undefined if prop path does not exist', (done) => {
+        runTestCases([
+            { // a key does not exist
+                input: `{{get 'z.z' options}}`,
+                output: ``,
+            },
+            { // first key exists, but its value is `undefined`
+                input:`{{get '0.zyx' (pluck (arrayify options) 'b')}}`, // array: [ undefined ]
                 output: ``,
             }
         ], done);

--- a/spec/helpers/lib/common.js
+++ b/spec/helpers/lib/common.js
@@ -74,6 +74,8 @@ describe('common utils', function () {
             expect(getValue(globals, obj, 'a.c.23')).to.equal(undefined);
             expect(getValue(globals, obj, 'ab')).to.equal(undefined);
             expect(getValue(globals, obj, 'nonexistent')).to.equal(undefined);
+            expect(getValue(globals, [ undefined ], '0.x')).to.equal(undefined);
+            expect(getValue(globals, [ null ], '0.x')).to.equal(undefined);
             done();
         });
 


### PR DESCRIPTION
## What? Why?

The new `getValue` function in `helpers/lib/common.js` was missing a check needed to safely handle cases like
```js
getValue(globals, {a: undefined}, 'a.b');
```

## How was it tested?

Unit test cases added for both `getValue` and one of the helpers using it.

----

cc @bigcommerce/storefront-team
