### PR TITLE
[STRF-9949] paper-handlebars - cdn helper, add new resourceHints attribute

### DIFF
--- a/helpers/cdn.js
+++ b/helpers/cdn.js
@@ -1,6 +1,26 @@
 'use strict';
 
-const factory = require('./lib/cdnify');
+const cdnify = require('./lib/cdnify');
+const {addResourceHint} = require('./lib/resourceHints');
+
+const factory = globals => {
+    const cdn = cdnify(globals);
+
+    return function (path) {
+        const fullPath = cdn(path);
+
+        const options = arguments[arguments.length - 1];
+        if (options.hash.resourceHint) {
+            addResourceHint(
+                globals,
+                fullPath,
+                options.hash.resourceHint
+            );
+        }
+
+        return fullPath;
+    };
+};
 
 module.exports = [{
     name: 'cdn',


### PR DESCRIPTION
## What? Why?

enable `cdn` helper to optionally produce resource hints.

## How was it tested?

unit tests

----

cc @bigcommerce/storefront-team
