### PR TITLE
removes type attribute from earlyHint helper. it will be reimplemented properly.

### DIFF
--- a/helpers/earlyHint.js
+++ b/helpers/earlyHint.js
@@ -6,14 +6,13 @@ const factory = globals => {
     return function (path, state) {
         const options = arguments[arguments.length - 1];
 
-        const type = options.hash.type;
         const cors = options.hash.cors;
 
         addResourceHint(
             globals,
             path,
             state,
-            type,
+            undefined,
             cors
         );
 

--- a/spec/helpers/earlyHint.js
+++ b/spec/helpers/earlyHint.js
@@ -6,15 +6,13 @@ const Lab = require('lab'),
 const {buildRenderer, testRunner} = require("../spec-helpers");
 const {expect} = require("code");
 const {
-    resourceHintAllowedTypes,
     resourceHintAllowedStates,
     resourceHintAllowedCors
 } = require("../../helpers/lib/resourceHints");
 
-function template(path, state, type, cors) {
-    type = type ? `type="${type}"` : '';
+function template(path, state, cors) {
     cors = cors ? `cors="${cors}"` : '';
-    return `{{ earlyHint "${path}" "${state}" ${type} ${cors} }}`;
+    return `{{ earlyHint "${path}" "${state}" ${cors} }}`;
 }
 
 function randommer(items) {
@@ -22,7 +20,6 @@ function randommer(items) {
 }
 
 const randomHintState = randommer(Object.values(resourceHintAllowedStates));
-const randomHintType = randommer(Object.values(resourceHintAllowedTypes));
 const randomCors = randommer(Object.values(resourceHintAllowedCors));
 
 let renderer, runTests;
@@ -54,10 +51,9 @@ describe('earlyHint', () => {
 
     it('should create a resource hint with all the properties', done => {
         const path = '/asset/theme.css'
-        const type = randomHintType();
         const state = randomHintState();
         const cors = randomCors();
-        const input = template(path, state, type, cors);
+        const input = template(path, state, cors);
         runTests([
             {
                 input,
@@ -66,7 +62,7 @@ describe('earlyHint', () => {
         ], () => {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(1);
-            expect(hints[0]).to.equals({src: path, state, type, cors});
+            expect(hints[0]).to.equals({src: path, state, cors});
             done();
         });
     });


### PR DESCRIPTION
## What? Why?

Removes `type` attribute in `earlyHint` helper.
It will be properly implemented in conjunction with the `as` attribute.

## How was it tested?

unit tests

----

cc @bigcommerce/storefront-team
