### PR TITLE
[STRF-10096] - storefront - investigate google fonts css uri encoding issue

### DIFF
--- a/helpers/cdn.js
+++ b/helpers/cdn.js
@@ -7,11 +7,11 @@ const factory = globals => {
     const cdn = cdnify(globals);
 
     return function (path) {
-        const fullPath = cdn(path);
+        let fullPath = cdn(path);
 
         const options = arguments[arguments.length - 1];
         if (options.hash.resourceHint) {
-            addResourceHint(
+            fullPath = addResourceHint(
                 globals,
                 fullPath,
                 options.hash.resourceHint

--- a/helpers/earlyHint.js
+++ b/helpers/earlyHint.js
@@ -8,15 +8,13 @@ const factory = globals => {
 
         const cors = options.hash.cors;
 
-        addResourceHint(
+        return addResourceHint(
             globals,
             path,
             state,
             undefined,
             cors
         );
-
-        return path;
     }
 };
 

--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
+const URL = require('url')
 
-const {resourceHintAllowedTypes, addResourceHint} = require('../lib/resourceHints');
+const { resourceHintAllowedTypes, addResourceHint } = require('../lib/resourceHints');
 
 const fontProviders = {
     'Google': {
@@ -19,7 +20,7 @@ const fontProviders = {
          *
          * @returns {string}
          */
-        parser: function(fonts) {
+        parser: function (fonts) {
             var collection = [],
                 familyHash = {};
 
@@ -53,13 +54,19 @@ const fontProviders = {
             return collection;
         },
 
-        buildLink: function(fonts, fontDisplay) {
+        buildLink: function (fonts, fontDisplay) {
             const displayTypes = ['auto', 'block', 'swap', 'fallback', 'optional'];
             fontDisplay = displayTypes.includes(fontDisplay) ? fontDisplay : 'swap';
-            return `<link href="https://fonts.googleapis.com/css?family=${fonts.join('|')}&display=${fontDisplay}" rel="stylesheet">`;
+            const uri = `https://fonts.googleapis.com/css?family=${fonts.join('|')}&display=${fontDisplay}`
+            try {
+                const url = URL.parse(uri);
+                return `<link href="${url.format()}" rel="stylesheet">`;
+            } catch (error) {
+                throw new Error(`Invalid URL [${uri}]. Check configured fonts.`)
+            }
         },
 
-        buildFontLoaderConfig: function(fonts) {
+        buildFontLoaderConfig: function (fonts) {
             function replaceSpaces(font) {
                 return font.split('+').join(' ');
             }
@@ -97,10 +104,10 @@ const fontProviders = {
  * @param {Object} options an optional object for additional configuration details
  * @returns {Object.<string, Array>|string}
  */
-module.exports = function(format, themeSettings, handlebars, options) {
+module.exports = function (format, themeSettings, handlebars, options) {
 
     const collectedFonts = {};
-    _.each(themeSettings, function(value, key) {
+    _.each(themeSettings, function (value, key) {
         //check that -font is on end of string but not start of string
         const fontKeySuffix = '-font';
         if (!key.endsWith(fontKeySuffix)) {
@@ -122,37 +129,37 @@ module.exports = function(format, themeSettings, handlebars, options) {
     });
 
     // Parse font strings based on provider
-    const parsedFonts = _.mapValues(collectedFonts, function(value, key) {
+    const parsedFonts = _.mapValues(collectedFonts, function (value, key) {
         return fontProviders[key].parser(value);
     });
 
     // Format output based on requested format
-    switch(format) {
-    case 'linkElements':
+    switch (format) {
+        case 'linkElements':
 
-        const formattedFonts = _.mapValues(parsedFonts, function(value, key) {
-            if (options.globals && options.state) {
-                fontProviders[key].generateResourceHints(options.globals, options.state, value, options.fontDisplay);
-            }
-            return fontProviders[key].buildLink(value, options.fontDisplay);
-        });
-        return new handlebars.SafeString(_.values(formattedFonts).join(''));
+            const formattedFonts = _.mapValues(parsedFonts, function (value, key) {
+                if (options.globals && options.state) {
+                    fontProviders[key].generateResourceHints(options.globals, options.state, value, options.fontDisplay);
+                }
+                return fontProviders[key].buildLink(value, options.fontDisplay);
+            });
+            return new handlebars.SafeString(_.values(formattedFonts).join(''));
 
-    case 'webFontLoaderConfig':
-        // Build configs
-        const configs = _.mapValues(parsedFonts, function(value, key) {
-            return fontProviders[key].buildFontLoaderConfig(value);
-        });
+        case 'webFontLoaderConfig':
+            // Build configs
+            const configs = _.mapValues(parsedFonts, function (value, key) {
+                return fontProviders[key].buildFontLoaderConfig(value);
+            });
 
-        // Merge them
-        const fontLoaderConfig = {};
-        _.each(configs, function(config) {
-            return Object.assign(fontLoaderConfig, config);
-        });
-        return fontLoaderConfig;
+            // Merge them
+            const fontLoaderConfig = {};
+            _.each(configs, function (config) {
+                return Object.assign(fontLoaderConfig, config);
+            });
+            return fontLoaderConfig;
 
-    case 'providerLists':
-    default:
-        return parsedFonts;
+        case 'providerLists':
+        default:
+            return parsedFonts;
     }
 }

--- a/helpers/lib/resourceHints.js
+++ b/helpers/lib/resourceHints.js
@@ -1,4 +1,5 @@
 const utils = require("handlebars-utils");
+const URL = require('url');
 
 const resourceHintsLimit = 50;
 
@@ -30,6 +31,11 @@ function addResourceHint(globals, path, state, type, cors) {
         throw new Error('Invalid path provided. path should be a non empty string');
     }
     path = path.trim();
+    try {
+        path = URL.parse(path).format();
+    } catch (error) {
+        throw new Error(`Invalid value (resource URL) provided: [${path}]`)
+    }
 
     if (!utils.isString(state) || !resourceHintStates.includes(state)) {
         throw new Error(`resourceHint attribute received invalid value. Valid values are: ${resourceHintStates}`);
@@ -62,6 +68,8 @@ function addResourceHint(globals, path, state, type, cors) {
     hint.cors = cors;
 
     globals.resourceHints.push(hint);
+
+    return path;
 }
 
 module.exports = {

--- a/helpers/lib/resourceHints.js
+++ b/helpers/lib/resourceHints.js
@@ -34,7 +34,7 @@ function addResourceHint(globals, path, state, type, cors) {
     try {
         path = URL.parse(path).format();
     } catch (error) {
-        throw new Error(`Invalid value (resource URL) provided: [${path}]`)
+        throw new Error(`Invalid value (resource URL) provided: ${path}`)
     }
 
     if (!utils.isString(state) || !resourceHintStates.includes(state)) {

--- a/helpers/resourceHints.js
+++ b/helpers/resourceHints.js
@@ -40,8 +40,8 @@ const factory = globals => {
             }
         }
 
-        hosts.forEach(host => {
-            addResourceHint(
+        hosts = hosts.map(host => {
+            return addResourceHint(
                 globals,
                 host,
                 resourceHintAllowedStates.dnsPrefetchResourceHintState,

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const URL = require('url');
-
 const buildCDNHelper = require('./lib/cdnify');
 const {addResourceHint, resourceHintAllowedTypes} = require('./lib/resourceHints');
 

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -1,11 +1,14 @@
 'use strict';
 
+const URL = require('url');
+
 const buildCDNHelper = require('./lib/cdnify');
 const {addResourceHint, resourceHintAllowedTypes} = require('./lib/resourceHints');
 
 const factory = globals => {
+    const cdnify = buildCDNHelper(globals);
+
     return function (assetPath) {
-        const cdnify = buildCDNHelper(globals);
         const siteSettings = globals.getSiteSettings();
         const configId = siteSettings.theme_config_id;
 
@@ -16,10 +19,11 @@ const factory = globals => {
             ? assetPath.replace(/\.css$/, `-${configId}.css`)
             : assetPath;
 
-        const url = cdnify(path);
+        let url = cdnify(path);
+
 
         if (options.hash.resourceHint) {
-            addResourceHint(
+            url = addResourceHint(
                 globals,
                 url,
                 options.hash.resourceHint,

--- a/spec/helpers/getFontsCollection.js
+++ b/spec/helpers/getFontsCollection.js
@@ -21,7 +21,7 @@ describe('getFontsCollection', function () {
         };
         const renderer = buildRenderer({}, themeSettings);
         const runTestCases = testRunner({renderer});
-        const href = "https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700&display=swap";
+        const href = "https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700%7CKarla:700%7CLora:400%7CVolkron:%7CDroid:400,700%7CCrimson+Text:400,700&display=swap";
         runTestCases([
             {
                 input: '{{getFontsCollection resourceHint="preload"}}',
@@ -53,7 +53,7 @@ describe('getFontsCollection', function () {
         runTestCases([
             {
                 input: '{{getFontsCollection font-display="oreo"}}',
-                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700&display=swap" rel="stylesheet">',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700%7CKarla:700%7CLora:400%7CVolkron:%7CDroid:400,700%7CCrimson+Text:400,700&display=swap" rel="stylesheet">',
             },
         ], done);
     });
@@ -74,7 +74,7 @@ describe('getFontsCollection', function () {
         runTestCases([
             {
                 input: '{{getFontsCollection font-display="fallback"}}',
-                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700&display=fallback" rel="stylesheet">',
+                output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700%7CKarla:700%7CLora:400%7CVolkron:%7CDroid:400,700%7CCrimson+Text:400,700&display=fallback" rel="stylesheet">',
             },
         ], done);
     });

--- a/spec/helpers/lib/resourceHints.js
+++ b/spec/helpers/lib/resourceHints.js
@@ -15,13 +15,13 @@ describe('resource hints', function () {
     describe('addResourceHint', function () {
 
         it("creates resource hints when valid params are provided", (done) => {
-            const globals = { resourceHints: [] };
+            const globals = {resourceHints: []};
 
             const src = '/my/styles.css';
             const type = 'style';
             const state = 'preload';
             const cors = 'anonymous';
-            const expected = { src, state, type, cors };
+            const expected = {src, state, type, cors};
 
             addResourceHint(globals, src, state, type, cors);
 
@@ -37,7 +37,7 @@ describe('resource hints', function () {
             const src = '/my/styles.css';
             const type = 'style';
             const state = 'preload';
-            const expected = { src, state, type, cors: 'no' };
+            const expected = {src, state, type, cors: 'no'};
 
             addResourceHint(globals, src, state, type);
 
@@ -48,7 +48,7 @@ describe('resource hints', function () {
         });
 
         it('does not add a hint when provided path is invalid', (done) => {
-            const globals = { resourceHints: [] };
+            const globals = {resourceHints: []};
 
             const throws = [undefined, null, ''].map(s => {
                 return () => {
@@ -71,7 +71,7 @@ describe('resource hints', function () {
         });
 
         it('does create a hint when no type is provided', (done) => {
-            const globals = { resourceHints: [] };
+            const globals = {resourceHints: []};
 
             addResourceHint(
                 globals,
@@ -86,7 +86,7 @@ describe('resource hints', function () {
         });
 
         it('does not create a hint when provided state param is not supported', (done) => {
-            const globals = { resourceHints: [] };
+            const globals = {resourceHints: []};
 
             const f = () => addResourceHint(
                 globals,
@@ -100,7 +100,7 @@ describe('resource hints', function () {
         });
 
         it('does not create duplicate, by src, hints', (done) => {
-            const globals = { resourceHints: [] };
+            const globals = {resourceHints: []};
 
             const src = '/my/styles.css';
             const type = 'style';
@@ -122,7 +122,7 @@ describe('resource hints', function () {
 
         it('does not create any hint when the limit of allowed hints was reached', (done) => {
             const filled = Array(50).fill(1);
-            const globals = { resourceHints: filled };
+            const globals = {resourceHints: filled};
 
             addResourceHint(
                 globals,
@@ -142,24 +142,30 @@ describe('resource hints', function () {
             done();
         });
 
-        it('should url with special chars', done => {
-            const data = [{
-                original: "https://bigcommerce.paystackintegrations.com/js/script.js?store_hash=cag1k6vhir&installed_at=Tue May 10 2022 08:57:26 GMT+0000 (Coordinated Universal Time)",
-                expected: "https://bigcommerce.paystackintegrations.com/js/script.js?store_hash=cag1k6vhir&installed_at=Tue%20May%2010%202022%2008:57:26%20GMT+0000%20(Coordinated%20Universal%20Time)"
-            },
-            {
-                original: `https://instocknotify.blob.core.windows.net/stencil/cfa17df4-72e5-4c23-a4c7-1fa6903bdeb4.js?ts=17443383" type="text/javascript""`,
-                expected: "https://instocknotify.blob.core.windows.net/stencil/cfa17df4-72e5-4c23-a4c7-1fa6903bdeb4.js?ts=17443383%22%20type=%22text/javascript%22%22"
-            },
-            {
-                original: `https://instocknotify.blob.core.windows.net/stencil/41f9521c-57b6-4920-827b-77ba3477fcb5.js?ts=34911865" type="text/javascript"></script> <!--End InStockNotify Stencil Script -->`,
-                expected: "https://instocknotify.blob.core.windows.net/stencil/41f9521c-57b6-4920-827b-77ba3477fcb5.js?ts=34911865%22%20type=%22text/javascript%22%3E%3C/script%3E%20%3C!--End%20InStockNotify%20Stencil%20Script%20--%3E"
-            },
-            {
-                original: `https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400,500,700&display=block`,
-                expected: `https://fonts.googleapis.com/css?family=Karla:400%7CMontserrat:400,500,700&display=block`
-            }];
-            const globals = { resourceHints: [] };
+        it('should handle URLs with special chars', done => {
+            const data = [
+                {
+                    original: "https://bigcommerce.paystackintegrations.com/js/script.js?store_hash=cag1k6vhir&installed_at=Tue May 10 2022 08:57:26 GMT+0000 (Coordinated Universal Time)",
+                    expected: "https://bigcommerce.paystackintegrations.com/js/script.js?store_hash=cag1k6vhir&installed_at=Tue%20May%2010%202022%2008:57:26%20GMT+0000%20(Coordinated%20Universal%20Time)"
+                },
+                {
+                    original: `https://instocknotify.blob.core.windows.net/stencil/cfa17df4-72e5-4c23-a4c7-1fa6903bdeb4.js?ts=17443383" type="text/javascript""`,
+                    expected: "https://instocknotify.blob.core.windows.net/stencil/cfa17df4-72e5-4c23-a4c7-1fa6903bdeb4.js?ts=17443383%22%20type=%22text/javascript%22%22"
+                },
+                {
+                    original: `https://instocknotify.blob.core.windows.net/stencil/41f9521c-57b6-4920-827b-77ba3477fcb5.js?ts=34911865" type="text/javascript"></script> <!--End InStockNotify Stencil Script -->`,
+                    expected: "https://instocknotify.blob.core.windows.net/stencil/41f9521c-57b6-4920-827b-77ba3477fcb5.js?ts=34911865%22%20type=%22text/javascript%22%3E%3C/script%3E%20%3C!--End%20InStockNotify%20Stencil%20Script%20--%3E"
+                },
+                {
+                    original: `https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400,500,700&display=block`,
+                    expected: `https://fonts.googleapis.com/css?family=Karla:400%7CMontserrat:400,500,700&display=block`
+                },
+                {
+                    original: '/relative/asset/background.png?why=not',
+                    expected: '/relative/asset/background.png?why=not'
+                }
+            ];
+            const globals = {resourceHints: []};
 
             data.forEach(pair => {
                 const {original, expected} = pair;
@@ -173,6 +179,14 @@ describe('resource hints', function () {
                     addResourceHint(globals, original, state, type, cors)
                 );
             });
+            done();
+        });
+
+        it('should throw when invalid URL is passed in', done => {
+            const globals = {resourceHints: []};
+            const invalid = '';
+            const f = () => addResourceHint(globals, invalid, 'style', 'preload', 'no')
+            expect(f).to.throw();
             done();
         });
     });

--- a/spec/helpers/lib/resourceHints.js
+++ b/spec/helpers/lib/resourceHints.js
@@ -15,13 +15,13 @@ describe('resource hints', function () {
     describe('addResourceHint', function () {
 
         it("creates resource hints when valid params are provided", (done) => {
-            const globals = {resourceHints: []};
+            const globals = { resourceHints: [] };
 
             const src = '/my/styles.css';
             const type = 'style';
             const state = 'preload';
             const cors = 'anonymous';
-            const expected = {src, state, type, cors};
+            const expected = { src, state, type, cors };
 
             addResourceHint(globals, src, state, type, cors);
 
@@ -37,7 +37,7 @@ describe('resource hints', function () {
             const src = '/my/styles.css';
             const type = 'style';
             const state = 'preload';
-            const expected = {src, state, type, cors: 'no'};
+            const expected = { src, state, type, cors: 'no' };
 
             addResourceHint(globals, src, state, type);
 
@@ -48,7 +48,7 @@ describe('resource hints', function () {
         });
 
         it('does not add a hint when provided path is invalid', (done) => {
-            const globals = {resourceHints: []};
+            const globals = { resourceHints: [] };
 
             const throws = [undefined, null, ''].map(s => {
                 return () => {
@@ -71,7 +71,7 @@ describe('resource hints', function () {
         });
 
         it('does create a hint when no type is provided', (done) => {
-            const globals = {resourceHints: []};
+            const globals = { resourceHints: [] };
 
             addResourceHint(
                 globals,
@@ -86,7 +86,7 @@ describe('resource hints', function () {
         });
 
         it('does not create a hint when provided state param is not supported', (done) => {
-            const globals = {resourceHints: []};
+            const globals = { resourceHints: [] };
 
             const f = () => addResourceHint(
                 globals,
@@ -100,7 +100,7 @@ describe('resource hints', function () {
         });
 
         it('does not create duplicate, by src, hints', (done) => {
-            const globals = {resourceHints: []};
+            const globals = { resourceHints: [] };
 
             const src = '/my/styles.css';
             const type = 'style';
@@ -122,7 +122,7 @@ describe('resource hints', function () {
 
         it('does not create any hint when the limit of allowed hints was reached', (done) => {
             const filled = Array(50).fill(1);
-            const globals = {resourceHints: filled};
+            const globals = { resourceHints: filled };
 
             addResourceHint(
                 globals,
@@ -139,6 +139,40 @@ describe('resource hints', function () {
         it('should throw when invalid cors value is provided', done => {
             const f = () => addResourceHint({}, '/theme.css', 'style', 'preload', 'invalid-cors');
             expect(f).to.throw();
+            done();
+        });
+
+        it('should url with special chars', done => {
+            const data = [{
+                original: "https://bigcommerce.paystackintegrations.com/js/script.js?store_hash=cag1k6vhir&installed_at=Tue May 10 2022 08:57:26 GMT+0000 (Coordinated Universal Time)",
+                expected: "https://bigcommerce.paystackintegrations.com/js/script.js?store_hash=cag1k6vhir&installed_at=Tue%20May%2010%202022%2008:57:26%20GMT+0000%20(Coordinated%20Universal%20Time)"
+            },
+            {
+                original: `https://instocknotify.blob.core.windows.net/stencil/cfa17df4-72e5-4c23-a4c7-1fa6903bdeb4.js?ts=17443383" type="text/javascript""`,
+                expected: "https://instocknotify.blob.core.windows.net/stencil/cfa17df4-72e5-4c23-a4c7-1fa6903bdeb4.js?ts=17443383%22%20type=%22text/javascript%22%22"
+            },
+            {
+                original: `https://instocknotify.blob.core.windows.net/stencil/41f9521c-57b6-4920-827b-77ba3477fcb5.js?ts=34911865" type="text/javascript"></script> <!--End InStockNotify Stencil Script -->`,
+                expected: "https://instocknotify.blob.core.windows.net/stencil/41f9521c-57b6-4920-827b-77ba3477fcb5.js?ts=34911865%22%20type=%22text/javascript%22%3E%3C/script%3E%20%3C!--End%20InStockNotify%20Stencil%20Script%20--%3E"
+            },
+            {
+                original: `https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400,500,700&display=block`,
+                expected: `https://fonts.googleapis.com/css?family=Karla:400%7CMontserrat:400,500,700&display=block`
+            }];
+            const globals = { resourceHints: [] };
+
+            data.forEach(pair => {
+                const {original, expected} = pair;
+
+                const type = 'style';
+                const state = 'preload';
+                const cors = 'anonymous';
+
+                expect(
+                    expected,
+                    addResourceHint(globals, original, state, type, cors)
+                );
+            });
             done();
         });
     });

--- a/spec/helpers/resourceHints.js
+++ b/spec/helpers/resourceHints.js
@@ -30,7 +30,7 @@ describe('resourceHints', function () {
         runTestCases([
             {
                 input: '{{resourceHints}}',
-                output: '<link rel="dns-prefetch preconnect" href="https://fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="https://fonts.gstatic.com" crossorigin>',
+                output: '<link rel="dns-prefetch preconnect" href="https://fonts.googleapis.com/" crossorigin><link rel="dns-prefetch preconnect" href="https://fonts.gstatic.com/" crossorigin>',
             },
         ], () => {
             const hints = renderer.getResourceHints();


### PR DESCRIPTION
## What? Why?

After fully enabling early hints an issue with URL encoding was found: the URL for google fonts in Link headers are encoded but the same URLs in the `link` tag are not encoded, leading to requesting the fonts 2 times. Check the requests in this test https://www.webpagetest.org/result/220912_BiDcW5_D8J/1/details/#waterfall_view_step1

The proposed fix in this PR is that the code responsible for creating the data for early hints will use NodeJs `url` to `parse` the paths and the `format`ed version of the valid URL will be returned so any helper using this code will then use the valid URL to generate the HTML it needs to. The `url.parse` method throws when it receives invalid data so it already helps us to produce valid URLs. It is important to note that NodeJs `url` module does not follow RFC-3986 URI model. If there is a need to comply with RFC-3986, a new package should be installed: check: https://runkit.com/embed/hrxz28cj47n1 

## How was it tested?

Unit tests.

----

cc @bigcommerce/storefront-team
