### PR TITLE
Add original stack trace to render error

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ class HandlebarsRenderer {
             try {
                 result = template(context);
             } catch(e) {
-                return reject(new RenderError(e.message));
+                return reject(new RenderError(`${e.message} : ${e.stack}`));
             }
 
             // Apply decorators


### PR DESCRIPTION
## What? Why?

We're seeing a lot of errors about 'hash' undefined in renderer that spike occasionally and result in 500s https://kibana.bigcommerce.net/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(template_path,template_engine,message,store_id),filters:!(),index:production_containers_storefront-renderer,interval:auto,query:(language:kuery,query:'%22Cannot%20read%20property%20!'hash!'%20of%20null%22'),sort:!(!('@timestamp',desc)))

We're attempting to diagnose what exactly is failing within handlebars when we have a RenderError, so add the original stack trace to the error message 

## How was it tested?

----

cc @bigcommerce/storefront-team
