### PR TITLE
STRF-10061 remove handlebars-utils dependency

### DIFF
--- a/helpers/3p/html.js
+++ b/helpers/3p/html.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./utils');
 const striptags = require('./utils/lib/striptags');
 
 function parseAttributes(hash) {
-  return Object.keys(hash).map(function(key) {
+  return Object.keys(hash).map(function (key) {
     return key + '="' + hash[key] + '"';
   }).join(' ');
 };
 
 function sanitize(str) {
-  if (!utils.isString(str)) {return '';}
+  if (!utils.isString(str)) { return ''; }
   return striptags(str).trim();
 };
 
@@ -62,7 +62,7 @@ var helpers = module.exports;
  * @api public
  */
 
-helpers.ellipsis = function(str, limit) {
+helpers.ellipsis = function (str, limit) {
   if (str && typeof str === 'string') {
     if (str.length <= limit) {
       return str;
@@ -86,7 +86,7 @@ helpers.ellipsis = function(str, limit) {
  * @api public
  */
 
-helpers.sanitize = function(str) {
+helpers.sanitize = function (str) {
   return sanitize(str);
 };
 
@@ -101,8 +101,8 @@ helpers.sanitize = function(str) {
  * @api public
  */
 
-helpers.ul = function(context, options) {
-  return ('<ul ' + (parseAttributes(options.hash)) + '>') + context.map(function(item) {
+helpers.ul = function (context, options) {
+  return ('<ul ' + (parseAttributes(options.hash)) + '>') + context.map(function (item) {
     if (typeof item !== 'string') {
       item = options.fn(item);
     }
@@ -120,8 +120,8 @@ helpers.ul = function(context, options) {
  * @api public
  */
 
-helpers.ol = function(context, options) {
-  return ('<ol ' + (parseAttributes(options.hash)) + '>') + context.map(function(item) {
+helpers.ol = function (context, options) {
+  return ('<ol ' + (parseAttributes(options.hash)) + '>') + context.map(function (item) {
     if (typeof item !== 'string') {
       item = options.fn(item);
     }
@@ -142,7 +142,7 @@ helpers.ol = function(context, options) {
  * @api public
  */
 
-helpers.thumbnailImage = function(context) {
+helpers.thumbnailImage = function (context) {
   var figure = '';
   var image = '';
 

--- a/helpers/3p/utils/base.js
+++ b/helpers/3p/utils/base.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const { getValue } = require('../../lib/common');
 const getObject = require('../../../helpers/getObject');
 

--- a/helpers/3p/utils/index.js
+++ b/helpers/3p/utils/index.js
@@ -1,6 +1,27 @@
 'use strict';
 
-var utils = require('./utils');
+var utils = require('./base');
+
+/**
+ * Returns true if the given value is an object.
+ *
+ * ```js
+ * console.log(utils.isObject(null));
+ * //=> false
+ * console.log(utils.isObject([]));
+ * //=> false
+ * console.log(utils.isObject(function() {}));
+ * //=> false
+ * console.log(utils.isObject({}));
+ * //=> true
+ * ```
+ * @param {Object} `val`
+ * @return {Boolean}
+ * @api public
+ */
+utils.isObject = function (val) {
+  return typeof val === 'object';
+};
 
 /**
  * Returns true if the given value contains the given
@@ -12,7 +33,7 @@ var utils = require('./utils');
  * @return {Boolean}
  */
 
-utils.contains = function(val, obj, start) {
+utils.contains = function (val, obj, start) {
   var len = val ? val.length : 0;
   var idx = start < 0
     ? Math.max(0, len + start)
@@ -32,7 +53,7 @@ utils.contains = function(val, obj, start) {
       : utils.indexOf(val, obj, start)) > -1;
 
   } else {
-    utils.iterator(val, function(ele) {
+    utils.iterator(val, function (ele) {
       if (start < i++) {
         return !(res = (ele === obj));
       }
@@ -53,7 +74,7 @@ utils.contains = function(val, obj, start) {
  * @api public
  */
 
-utils.toRegex = function(val) {
+utils.toRegex = function (val) {
   return new RegExp(val.replace(/^\/|\/$/g, ''));
 };
 
@@ -66,7 +87,7 @@ utils.toRegex = function(val) {
  * @api public
  */
 
-utils.isRegex = function(val) {
+utils.isRegex = function (val) {
   if (utils.typeOf(val) === 'regexp') {
     return true;
   }
@@ -85,8 +106,8 @@ utils.isRegex = function(val) {
  * @return {String}
  */
 
-utils.chop = function(str) {
-  if (!utils.isString(str)) {return '';}
+utils.chop = function (str) {
+  if (!utils.isString(str)) { return ''; }
   var re = /^[-_.\W\s]+|[-_.\W\s]+$/g;
   return str.trim().replace(re, '');
 };
@@ -108,8 +129,8 @@ utils.chop = function(str) {
  * @api public
  */
 
-utils.changecase = function(str, fn) {
-  if (!utils.isString(str)) {return '';}
+utils.changecase = function (str, fn) {
+  if (!utils.isString(str)) { return ''; }
   if (str.length === 1) {
     return str.toLowerCase();
   }
@@ -120,7 +141,7 @@ utils.changecase = function(str, fn) {
   }
 
   var re = /[-_.\W\s]+(\w|$)/g;
-  return str.replace(re, function(_, ch) {
+  return str.replace(re, function (_, ch) {
     return fn(ch);
   });
 };
@@ -134,7 +155,7 @@ utils.changecase = function(str, fn) {
  * @api public
  */
 
-utils.random = function(min, max) {
+utils.random = function (min, max) {
   return min + Math.floor(Math.random() * (max - min + 1));
 };
 
@@ -147,7 +168,7 @@ utils.random = function(min, max) {
  * @api public
  */
 
-utils.isUndefined = function(val) {
+utils.isUndefined = function (val) {
   return typeof val === 'undefined'
     || (!!val.hash);
 };
@@ -160,7 +181,7 @@ utils.isUndefined = function(val) {
  * @api public
  */
 
-utils.isOptions = function(val) {
+utils.isOptions = function (val) {
   return utils.isObject(val) && val.hasOwnProperty('hash');
 };
 
@@ -172,7 +193,7 @@ utils.isOptions = function(val) {
  * @api public
  */
 
-utils.getArgs = function(app, args) {
+utils.getArgs = function (app, args) {
   var opts = utils.merge({}, app && app.options);
   if (!Array.isArray(args)) {
     args = [].slice.call(args);
@@ -186,8 +207,8 @@ utils.getArgs = function(app, args) {
     opts = utils.get(opts, hbsOptions.name) || opts;
     opts = utils.merge({}, opts, hbsOptions.hash);
 
-  // if the last arg is an object, merge it
-  // into the options
+    // if the last arg is an object, merge it
+    // into the options
   } else if (utils.isObject(last)) {
     opts = utils.merge({}, opts, args.pop());
   }
@@ -205,7 +226,7 @@ utils.getArgs = function(app, args) {
  * @api public
  */
 
-utils.isObject = function(val) {
+utils.isObject = function (val) {
   return val && typeof val === 'object'
     && !Array.isArray(val);
 };
@@ -218,7 +239,7 @@ utils.isObject = function(val) {
  * @api public
  */
 
-utils.isEmpty = function(val) {
+utils.isEmpty = function (val) {
   if (val === 0 || val === '0') {
     return false;
   }
@@ -241,10 +262,10 @@ utils.isEmpty = function(val) {
  * @api public
  */
 
-utils.tryParse = function(str) {
+utils.tryParse = function (str) {
   try {
     return JSON.parse(str);
-  } catch (err) {}
+  } catch (err) { }
   return null;
 };
 
@@ -257,7 +278,7 @@ utils.tryParse = function(str) {
  * @api public
  */
 
-utils.result = function(value) {
+utils.result = function (value) {
   if (typeof value === 'function') {
     return value();
   }
@@ -272,7 +293,7 @@ utils.result = function(value) {
  * @api public
  */
 
-utils.identity = function(val) {
+utils.identity = function (val) {
   return val;
 };
 
@@ -284,7 +305,7 @@ utils.identity = function(val) {
  * @api public
  */
 
-utils.isString = function(val) {
+utils.isString = function (val) {
   return val && typeof val === 'string';
 };
 
@@ -296,8 +317,106 @@ utils.isString = function(val) {
  * @api public
  */
 
-utils.arrayify = function(val) {
+utils.arrayify = function (val) {
   return val ? (Array.isArray(val) ? val : [val]) : [];
+};
+
+utils.isArray = Array.isArray;
+
+/**
+ * Get the context to use for rendering.
+ *
+ * @param {Object} `thisArg` Optional invocation context `this`
+ * @return {Object}
+ * @api public
+ */
+
+utils.context = function (thisArg, locals, options) {
+  if (utils.isOptions(thisArg)) {
+    return utils.context({}, locals, thisArg);
+  }
+  // ensure args are in the correct order
+  if (utils.isOptions(locals)) {
+    return utils.context(thisArg, options, locals);
+  }
+  var appContext = utils.isApp(thisArg) ? thisArg.context : {};
+  options = options || {};
+
+  // if "options" is not handlebars options, merge it onto locals
+  if (!utils.isOptions(options)) {
+    locals = Object.assign({}, locals, options);
+  }
+  // merge handlebars root data onto locals if specified on the hash
+  if (utils.isOptions(options) && options.hash.root === true) {
+    locals = Object.assign({}, options.data.root, locals);
+  }
+  var context = Object.assign({}, appContext, locals, options.hash);
+  if (!utils.isApp(thisArg)) {
+    context = Object.assign({}, thisArg, context);
+  }
+  if (utils.isApp(thisArg) && thisArg.view && thisArg.view.data) {
+    context = Object.assign({}, context, thisArg.view.data);
+  }
+  return context;
+};
+
+/**
+ * Creates an options object from the `context`, `locals` and `options.`
+ * Handlebars' `options.hash` is merged onto the options, and if the context
+ * is created by [templates][], `this.options` will be merged onto the
+ * options as well.
+ *
+ * @param {Object} `context`
+ * @param {Object} `locals` Options or locals
+ * @param {Object} `options`
+ * @return {Boolean}
+ * @api public
+ */
+
+utils.options = function (thisArg, locals, options) {
+  if (utils.isOptions(thisArg)) {
+    return utils.options({}, locals, thisArg);
+  }
+  if (utils.isOptions(locals)) {
+    return utils.options(thisArg, options, locals);
+  }
+  options = options || {};
+  if (!utils.isOptions(options)) {
+    locals = Object.assign({}, locals, options);
+  }
+  var opts = Object.assign({}, locals, options.hash);
+  if (utils.isObject(thisArg)) {
+    opts = Object.assign({}, thisArg.options, opts);
+  }
+  if (opts[options.name]) {
+    opts = Object.assign({}, opts[options.name], opts);
+  }
+  return opts;
+};
+
+/**
+ * Returns true if an `app` propery is on the context, which means
+ * the context was created by [assemble][], [templates][], [verb][],
+ * or any other library that follows this convention.
+ *
+ * ```js
+ * Handlebars.registerHelper('example', function(val, options) {
+ *   var context = options.hash;
+ *   if (utils.isApp(this)) {
+ *     context = Object.assign({}, this.context, context);
+ *   }
+ *   // do stuff
+ * });
+ * ```
+ * @param {any} `value`
+ * @return {Boolean}
+ * @api public
+ */
+
+utils.isApp = function (thisArg) {
+  return utils.isObject(thisArg)
+    && utils.isObject(thisArg.options)
+    && utils.isObject(thisArg.app);
 };
 
 /**

--- a/helpers/3p/utils/lib/createFrame.js
+++ b/helpers/3p/utils/lib/createFrame.js
@@ -4,9 +4,17 @@
  * https://github.com/jonschlinkert/define-property/blob/master/index.js
  */
 
+function extend(obj /* , ...source */) {
+  for (var i = 1; i < arguments.length; i++) {
+    for (var key in arguments[i]) {
+      if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
+        obj[key] = arguments[i][key];
+      }
+    }
+  }
 
-const utils = require('handlebars-utils');
-
+  return obj;
+}
 
 function defineProperty(obj, prop, val) {
   if (typeof obj !== 'object' && typeof obj !== 'function') {
@@ -27,15 +35,14 @@ function defineProperty(obj, prop, val) {
 };
 
 module.exports = function createFrame(data) {
-  if (!utils.isObject(data)) {
+  if (typeof data !== 'object') {
     throw new TypeError('createFrame expects data to be an object');
   }
 
-  var extend = utils.extend;
   var frame = extend({}, data);
   frame._parent = data;
 
-  defineProperty(frame, 'extend', function(data) {
+  defineProperty(frame, 'extend', function (data) {
     extend(this, data);
   });
 

--- a/helpers/3p/utils/lib/markdown.js
+++ b/helpers/3p/utils/lib/markdown.js
@@ -1,4 +1,3 @@
-const utils = require('handlebars-utils');
 const merge = require('./mixinDeep');
 const { Remarkable } = require('remarkable');
 
@@ -22,7 +21,7 @@ module.exports = function markdown(config) {
       return md.render(context);
     }
 
-    if (utils.isObject(context) && typeof context.fn === 'function') {
+    if (typeof context === 'object' && typeof context.fn === 'function') {
       options = context;
       context = {};
     }

--- a/helpers/all.js
+++ b/helpers/all.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 /**
  * Yield block only if all args are valid
@@ -10,7 +10,7 @@ const utils = require('handlebars-utils');
  * {{#all items theme_settings.optionA theme_settings.optionB}} ... {{/all}}
  */
 const factory = () => {
-    return function(...args) {
+    return function (...args) {
 
         // Take the last arg which is a Handlebars options object out of args array
         const opts = args.pop();

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 /**
  * Yield block if any object within a collection matches supplied predicate
@@ -10,7 +10,7 @@ const utils = require('handlebars-utils');
  * {{#any items selected=true}} ... {{/any}}
  */
 const factory = () => {
-    return function(...args) {
+    return function (...args) {
 
         let any;
         // Take the last arg which is a Handlebars options object out of args array

--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -1,10 +1,10 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const max_length = 1024;
 const max_keys = 50;
 
 const factory = globals => {
-    return function(key, value) {
+    return function (key, value) {
 
         // Validate that key is a string
         if (!utils.isString(key)) {

--- a/helpers/decrementVar.js
+++ b/helpers/decrementVar.js
@@ -1,9 +1,9 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const max_keys = 50;
 
 const factory = globals => {
-    return function(key) {
+    return function (key) {
         if (!utils.isString(key)) {
             throw new Error("decrementVar helper key must be a string");
         }
@@ -13,7 +13,7 @@ const factory = globals => {
             globals.storage.variables = {};
         }
 
-        if (globals.storage.variables.hasOwnProperty(key) &&Number.isInteger(globals.storage.variables[key])) {
+        if (globals.storage.variables.hasOwnProperty(key) && Number.isInteger(globals.storage.variables[key])) {
             // Decrement value if it already exists
             globals.storage.variables[key] -= 1;
         } else {
@@ -26,7 +26,7 @@ const factory = globals => {
         }
 
         // Return current value
-        return globals.storage.variables.hasOwnProperty(key) ? globals.storage.variables[key]: undefined;
+        return globals.storage.variables.hasOwnProperty(key) ? globals.storage.variables[key] : undefined;
     };
 };
 

--- a/helpers/encodeHtmlEntities.js
+++ b/helpers/encodeHtmlEntities.js
@@ -1,12 +1,12 @@
 'use strict';
 const he = require('he');
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const common = require('./lib/common.js');
 
 const factory = globals => {
-    return function(string) {
+    return function (string) {
         string = common.unwrapIfSafeString(globals.handlebars, string);
-        if (!utils.isString(string)){
+        if (!utils.isString(string)) {
             throw new TypeError("Non-string passed to encodeHtmlEntities");
         }
 

--- a/helpers/for.js
+++ b/helpers/for.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 const factory = () => {
-    return function(from, to, context) {
+    return function (from, to, context) {
         const options = arguments[arguments.length - 1];
         const maxIterations = 100;
         var output = '';

--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const getFonts = require('./lib/fonts');
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 const factory = globals => {
-    return function() {
+    return function () {
         const options = arguments[arguments.length - 1];
         const fontDisplay = options.hash['font-display'];
 
@@ -12,7 +12,7 @@ const factory = globals => {
             globals,
             state: options.hash.resourceHint,
             fontDisplay
-        } : {fontDisplay};
+        } : { fontDisplay };
 
         return getFonts('linkElements', globals.getThemeSettings(), globals.handlebars, getFontsOptions);
     };

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const common = require('./lib/common.js');
 
 const factory = globals => {
-    return function(image, presetName, defaultImageUrl) {
+    return function (image, presetName, defaultImageUrl) {
         var sizeRegex = /^(\d+?)x(\d+?)$/g;
         var settings = globals.getThemeSettings() || {};
         var presets = settings._images;

--- a/helpers/getImageSrcset.js
+++ b/helpers/getImageSrcset.js
@@ -1,9 +1,9 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const common = require('./lib/common');
 
 const factory = globals => {
-    return function(image, defaultImageUrl) {
+    return function (image, defaultImageUrl) {
         // Regex to test size string is of the form 123x123 or 100w
         const sizeRegex = /(^\d+w$)|(^(\d+?)x(\d+?)$)/;
         // Regex to test to that srcset descriptor is of the form 1x 1.5x 2x OR 123w
@@ -15,7 +15,7 @@ const factory = globals => {
             defaultImageUrl = '';
         }
 
-        if (!utils.isObject(image) || !utils.isString (image.data)
+        if (!utils.isObject(image) || !utils.isString(image.data)
             || !common.isValidURL(image.data) || image.data.indexOf('{:size}') === -1) {
             // return empty string if not a valid image object
             defaultImageUrl = defaultImageUrl ? defaultImageUrl : '';
@@ -25,7 +25,7 @@ const factory = globals => {
         let srcsets = {};
 
         if (options.hash['use_default_sizes']) {
-            if (Number.isInteger(image.width) && Number.isInteger(image.height)){
+            if (Number.isInteger(image.width) && Number.isInteger(image.height)) {
                 /* If we know the image dimensions, don't generate srcset sizes larger than the image  */
                 srcsets[`${image.width}w`] = `${image.width}w`;
                 const defaultSrcsetSizes = [2560, 1920, 1280, 960, 640, 320, 160, 80];

--- a/helpers/getImageSrcset1x2x.js
+++ b/helpers/getImageSrcset1x2x.js
@@ -1,9 +1,9 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const common = require('./lib/common');
 
 const factory = globals => {
-    return function(image, size1x) {
+    return function (image, size1x) {
         // Regex to test size string is of the form 123x123
         const pixelDimensionsRegex = /(^\d+w$)|(^(\d+?)x(\d+?)$)/;
         const return1x = (image, size1x) =>
@@ -18,7 +18,7 @@ const factory = globals => {
             throw new Error("Invalid size argument passed to getImageSrcset1x2x, must be a set of pixel dimensions of the format '123x123'")
         }
 
-        if(!image.width || !image.height || !Number.isInteger(image.width) || !Number.isInteger(image.height)) {
+        if (!image.width || !image.height || !Number.isInteger(image.width) || !Number.isInteger(image.height)) {
             return return1x(image, size1x);
         }
 
@@ -30,7 +30,7 @@ const factory = globals => {
             // or those sizes would be larger than the resizer supports
             return return1x(image, size1x);
         } else {
-            const smallestFactor = Math.min((image.width/width1x), (image.height/height1x));
+            const smallestFactor = Math.min((image.width / width1x), (image.height / height1x));
             const factor = smallestFactor < 2 ? smallestFactor : 2;
             const roundedFactor = +(factor).toFixed(4) //cast to Number for clean rounding
 

--- a/helpers/getVar.js
+++ b/helpers/getVar.js
@@ -1,8 +1,9 @@
 'use strict';
-const utils = require('handlebars-utils');
+
+const utils = require('./3p/utils');
 
 const factory = globals => {
-    return function(key) {
+    return function (key) {
         if (!utils.isString(key)) {
             throw new Error("getVar helper key must be a string");
         }

--- a/helpers/if.js
+++ b/helpers/if.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 const factory = globals => {
-    return function(lvalue, operator, rvalue) {
+    return function (lvalue, operator, rvalue) {
         const options = arguments[arguments.length - 1];
         let result;
 
@@ -31,52 +31,52 @@ const factory = globals => {
             }
 
             switch (operator) {
-            case '==':
-                result = (lvalue == rvalue);
-                break;
+                case '==':
+                    result = (lvalue == rvalue);
+                    break;
 
-            case '===':
-                result = (lvalue === rvalue);
-                break;
+                case '===':
+                    result = (lvalue === rvalue);
+                    break;
 
-            case '!=':
-                result = (lvalue != rvalue);
-                break;
+                case '!=':
+                    result = (lvalue != rvalue);
+                    break;
 
-            case '!==':
-                result = (lvalue !== rvalue);
-                break;
+                case '!==':
+                    result = (lvalue !== rvalue);
+                    break;
 
-            case '<':
-                result = (lvalue < rvalue);
-                break;
+                case '<':
+                    result = (lvalue < rvalue);
+                    break;
 
-            case '>':
-                result = (lvalue > rvalue);
-                break;
+                case '>':
+                    result = (lvalue > rvalue);
+                    break;
 
-            case '<=':
-                result = (lvalue <= rvalue);
-                break;
+                case '<=':
+                    result = (lvalue <= rvalue);
+                    break;
 
-            case '>=':
-                result = (lvalue >= rvalue);
-                break;
+                case '>=':
+                    result = (lvalue >= rvalue);
+                    break;
 
-            case 'gtnum':
-                if (typeof lvalue === 'string' && typeof(rvalue) === 'string' && !isNaN(lvalue) && !isNaN(rvalue)) {
-                    result = parseInt(lvalue) > parseInt(rvalue);
-                } else {
-                    throw new Error("if gtnum only accepts numbers (as strings)");
-                }
-                break;
+                case 'gtnum':
+                    if (typeof lvalue === 'string' && typeof (rvalue) === 'string' && !isNaN(lvalue) && !isNaN(rvalue)) {
+                        result = parseInt(lvalue) > parseInt(rvalue);
+                    } else {
+                        throw new Error("if gtnum only accepts numbers (as strings)");
+                    }
+                    break;
 
-            case 'typeof':
-                result = (typeof lvalue === rvalue);
-                break;
+                case 'typeof':
+                    result = (typeof lvalue === rvalue);
+                    break;
 
-            default:
-                throw new Error("Handlerbars Helper 'if' doesn't know the operator " + operator);
+                default:
+                    throw new Error("Handlerbars Helper 'if' doesn't know the operator " + operator);
             }
         }
 

--- a/helpers/incrementVar.js
+++ b/helpers/incrementVar.js
@@ -1,9 +1,9 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const max_keys = 50;
 
 const factory = globals => {
-    return function(key) {
+    return function (key) {
         if (!utils.isString(key)) {
             throw new Error("incrementVar helper key must be a string");
         }
@@ -26,7 +26,7 @@ const factory = globals => {
         }
 
         // Return current value
-        return globals.storage.variables.hasOwnProperty(key) ? globals.storage.variables[key]: undefined;
+        return globals.storage.variables.hasOwnProperty(key) ? globals.storage.variables[key] : undefined;
     };
 };
 

--- a/helpers/lib/getObjectStorageImage.js
+++ b/helpers/lib/getObjectStorageImage.js
@@ -1,5 +1,5 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('../3p/utils');
 const common = require('./common');
 
 const srcsets = {
@@ -14,7 +14,7 @@ const srcsets = {
 };
 
 function getObjectStorageImage(handlebars, cdnUrl, source, path, options) {
-    if (!utils.isString (path) || common.isValidURL(path)) {
+    if (!utils.isString(path) || common.isValidURL(path)) {
         throw new TypeError("Invalid image path - please use a filename or folder path starting from the appropriate folder");
     }
 
@@ -35,7 +35,7 @@ function getObjectStorageImage(handlebars, cdnUrl, source, path, options) {
 }
 
 function getObjectStorageImageSrcset(handlebars, cdnUrl, source, path) {
-    if (!utils.isString (path) || common.isValidURL(path)) {
+    if (!utils.isString(path) || common.isValidURL(path)) {
         throw new TypeError("Invalid image path - please use a filename or folder path starting from the appropriate folder");
     }
 

--- a/helpers/lib/resourceHints.js
+++ b/helpers/lib/resourceHints.js
@@ -1,4 +1,4 @@
-const utils = require("handlebars-utils");
+const utils = require("../3p/utils");
 
 const resourceHintsLimit = 50;
 
@@ -39,7 +39,7 @@ function addResourceHint(globals, path, state, type, cors) {
         globals.resourceHints = [];
     }
 
-    let index = globals.resourceHints.findIndex(({src}) => path === src);
+    let index = globals.resourceHints.findIndex(({ src }) => path === src);
     if (index >= 0) {
         return;
     }
@@ -48,7 +48,7 @@ function addResourceHint(globals, path, state, type, cors) {
         return;
     }
 
-    let hint = {src: path, state};
+    let hint = { src: path, state };
 
     if (utils.isString(type) && resourceHintTypes.includes(type)) {
         hint.type = type;
@@ -68,8 +68,8 @@ module.exports = {
     resourceHintsLimit,
     defaultResourceHintState: preloadResourceHintState,
     addResourceHint,
-    resourceHintAllowedTypes: {resourceHintStyleType, resourceHintFontType, resourceHintScriptType},
-    resourceHintAllowedCors: {noCors, anonymousCors, useCredentialsCors},
+    resourceHintAllowedTypes: { resourceHintStyleType, resourceHintFontType, resourceHintScriptType },
+    resourceHintAllowedCors: { noCors, anonymousCors, useCredentialsCors },
     resourceHintAllowedStates: {
         preloadResourceHintState,
         preconnectResourceHintState,

--- a/helpers/limit.js
+++ b/helpers/limit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 /**
  * Limit an array to the second argument
@@ -9,7 +9,7 @@ const utils = require('handlebars-utils');
  * {{limit array 4}}
  */
 const factory = () => {
-    return function(data, limit) {
+    return function (data, limit) {
         if (utils.isString(data)) {
             return data.substring(0, limit);
         }

--- a/helpers/moment.js
+++ b/helpers/moment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const date = require('date.js');
 
 // suppress error messages that are not actionable

--- a/helpers/option.js
+++ b/helpers/option.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const util = require('handlebars-utils');
+const utils = require('./3p/utils');
 const { getValue } = require('./lib/common');
 
 /**
@@ -21,7 +21,7 @@ const factory = (globals) => {
             path = '';
         }
 
-        let opts = util.options(this, locals, options);
+        let opts = utils.options(this, locals, options);
 
         return getValue(opts, path, globals);
     };

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 /**
  * Yield block if any object within a collection matches supplied predicate
@@ -10,7 +10,7 @@ const utils = require('handlebars-utils');
  * {{#or 1 0 0 0 0 0}} ... {{/or}}
  */
 const factory = () => {
-    return function(...args) {
+    return function (...args) {
 
         // Take the last arg which is a Handlebars options object out of args array
         const opts = args.pop();

--- a/helpers/resourceHints.js
+++ b/helpers/resourceHints.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const getFonts = require('./lib/fonts');
 const {
     addResourceHint,

--- a/helpers/setURLQueryParam.js
+++ b/helpers/setURLQueryParam.js
@@ -1,17 +1,17 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const common = require('./lib/common.js');
 
 const factory = globals => {
-    return function(string, key, value) {
+    return function (string, key, value) {
         string = common.unwrapIfSafeString(globals.handlebars, string);
         key = common.unwrapIfSafeString(globals.handlebars, key);
         value = common.unwrapIfSafeString(globals.handlebars, value);
-        if (!utils.isString(string) || !common.isValidURL(string)){
+        if (!utils.isString(string) || !common.isValidURL(string)) {
             throw new TypeError("Invalid URL passed to setURLQueryParam");
-        } else if (!utils.isString(key)){
+        } else if (!utils.isString(key)) {
             throw new TypeError("Invalid query parameter key passed to setURLQueryParam");
-        } else if(!utils.isString(value)) {
+        } else if (!utils.isString(value)) {
             throw new TypeError("Invalid query parameter value passed to setURLQueryParam");
         }
 

--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -1,19 +1,19 @@
 'use strict';
 const common = require('./lib/common.js');
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 
 const factory = globals => {
-    return function(str, substr, newSubstr, iteration) {
+    return function (str, substr, newSubstr, iteration) {
         str = common.unwrapIfSafeString(globals.handlebars, str);
         substr = common.unwrapIfSafeString(globals.handlebars, substr);
         newSubstr = common.unwrapIfSafeString(globals.handlebars, newSubstr);
         iteration = common.unwrapIfSafeString(globals.handlebars, iteration);
 
-        if (!utils.isString(str)){
+        if (!utils.isString(str)) {
             throw new TypeError("Invalid query parameter string passed to strReplace");
-        } else if (!utils.isString(substr)){
+        } else if (!utils.isString(substr)) {
             throw new TypeError("Invalid query paramter substring passed to strReplace");
-        } else if(!utils.isString(newSubstr)) {
+        } else if (!utils.isString(newSubstr)) {
             throw new TypeError("Invalid query parameter new substring passed to strReplace");
         }
 
@@ -44,7 +44,7 @@ function escapeRegex(string) {
 }
 
 function getOccurrences(str, substr) {
-    const matches = str.match(new RegExp(escapeRegex(substr),'g'));
+    const matches = str.match(new RegExp(escapeRegex(substr), 'g'));
     return matches ? matches.length : 0;
 }
 

--- a/helpers/stripQuerystring.js
+++ b/helpers/stripQuerystring.js
@@ -1,9 +1,9 @@
 'use strict';
-const utils = require('handlebars-utils');
+const utils = require('./3p/utils');
 const common = require('./lib/common.js');
 
 const factory = globals => {
-    return function(url) {
+    return function (url) {
         url = common.unwrapIfSafeString(globals.handlebars, url);
         if (utils.isString(url)) {
             return url.split('?')[0];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@bigcommerce/handlebars-v4": "4.7.6",
     "handlebars": "3.0.8",
     "handlebars-helpers": "0.8.4",
-    "handlebars-utils": "^1.0.6",
     "he": "^1.2.0",
     "lodash": "^4.17.21",
     "remarkable": "^2.0.1",


### PR DESCRIPTION
## What? Why?

* Finishes the removal of `handlebars-utils`
* Added missing functions (e.g, `isObject`) to `utils/index.js`
* Removed circular dependencies from `markdown` and `createFrame` modules

Also, renamed `utils.js` to `base.js` because it was confusing to have a submodule the same name as its parent module.

## How was it tested?

`npm run test`

----

cc @bigcommerce/storefront-team
