### PR TITLE
fix: STRF-10122 Fix inArray helper, when array is undefined

### DIFF
--- a/helpers/3p/utils/lib/indexOf.js
+++ b/helpers/3p/utils/lib/indexOf.js
@@ -9,7 +9,7 @@ module.exports = function indexOf(arr, ele, start) {
   start = start || 0;
   var idx = -1;
 
-  if (arr === null) {return idx;}
+  if (!arr) {return idx;}
   var len = arr.length;
   var i = start < 0
     ? (len + start)

--- a/spec/helpers/3p/utils/lib/indexOf.js
+++ b/spec/helpers/3p/utils/lib/indexOf.js
@@ -32,6 +32,11 @@ describe('indexOf', function () {
     done();
   });
 
+  it('should return -1 if the array is undefined', function (done) {
+    expect(indexOf(undefined, 'd')).to.equal(-1);
+    done();
+  });
+
   it('should get the index, starting from the given index:', function (done) {
     expect(indexOf(['a', 'b', 'c', 'a', 'b', 'c'], 'b', 2)).to.equal(4);
     expect(indexOf(['a', undefined, 'b', 'c', 'a'], undefined, 0)).to.equal(1);


### PR DESCRIPTION
## What? Why?

Original error:
 Cannot read property 'length' of undefined

Happened in inArray helper, when array is undefined.

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
