### PR TITLE
chore: release 5.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+## 5.1.3
+
+- fix: STRF-10122 Fix inArray helper, when array is undefined ([#201])[https://github.com/bigcommerce/paper-handlebars/pull/201]
+
 
 ## 5.1.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- fix: STRF-10122 Fix inArray helper, when array is undefined ([#201])[https://github.com/bigcommerce/paper-handlebars/pull/201]

cc @bigcommerce/storefront-team
