### PR TITLE
[STRF-10120] paper-handlebars - resource hints should include the proper values for PreloadResourceType

### DIFF
--- a/helpers/cdn.js
+++ b/helpers/cdn.js
@@ -10,11 +10,12 @@ const factory = globals => {
         let fullPath = cdn(path);
 
         const options = arguments[arguments.length - 1];
-        if (options.hash.resourceHint) {
+        if (options.hash && options.hash.resourceHint) {
             fullPath = addResourceHint(
                 globals,
                 fullPath,
-                options.hash.resourceHint
+                options.hash.resourceHint,
+                options.hash.as
             );
         }
 

--- a/helpers/earlyHint.js
+++ b/helpers/earlyHint.js
@@ -3,20 +3,20 @@
 const {addResourceHint} = require('./lib/resourceHints');
 
 const factory = globals => {
-    return function (path, state) {
+    return function (href, rel) {
         const options = arguments[arguments.length - 1];
 
         let cors, as = undefined;
 
         if (options && options.hash) {
-            cors = options.hash.cors;
+            cors = options.hash.crossorigin;
             as = options.hash.as;
         }
 
         return addResourceHint(
             globals,
-            path,
-            state,
+            href,
+            rel,
             as,
             cors
         );

--- a/helpers/earlyHint.js
+++ b/helpers/earlyHint.js
@@ -6,13 +6,18 @@ const factory = globals => {
     return function (path, state) {
         const options = arguments[arguments.length - 1];
 
-        const cors = options.hash.cors;
+        let cors, as = undefined;
+
+        if (options && options.hash) {
+            cors = options.hash.cors;
+            as = options.hash.as;
+        }
 
         return addResourceHint(
             globals,
             path,
             state,
-            undefined,
+            as,
             cors
         );
     }

--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -1,19 +1,12 @@
 'use strict';
 
 const getFonts = require('./lib/fonts');
-const utils = require('handlebars-utils');
 
 const factory = globals => {
-    return function() {
+    return function () {
         const options = arguments[arguments.length - 1];
         const fontDisplay = options.hash['font-display'];
-
-        const getFontsOptions = utils.isString(options.hash.resourceHint) ? {
-            globals,
-            state: options.hash.resourceHint,
-            fontDisplay
-        } : {fontDisplay};
-
+        const getFontsOptions = {globals, fontDisplay};
         return getFonts('linkElements', globals.getThemeSettings(), globals.handlebars, getFontsOptions);
     };
 };

--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const URL = require('url')
 
-const { resourceHintAllowedTypes, addResourceHint } = require('../lib/resourceHints');
+const { resourceHintAllowedTypes, addResourceHint, defaultResourceHintState } = require('../lib/resourceHints');
 
 const fontProviders = {
     'Google': {
@@ -78,14 +78,14 @@ const fontProviders = {
             };
         },
 
-        generateResourceHints: function (globals, state, fonts, fontDisplay) {
+        generateResourceHints: function (globals, fonts, fontDisplay) {
             const displayTypes = ['auto', 'block', 'swap', 'fallback', 'optional'];
             fontDisplay = displayTypes.includes(fontDisplay) ? fontDisplay : 'swap';
             const path = `https://fonts.googleapis.com/css?family=${fonts.join('|')}&display=${fontDisplay}`;
             addResourceHint(
                 globals,
                 path,
-                state,
+                defaultResourceHintState,
                 resourceHintAllowedTypes.resourceHintFontType
             );
         }
@@ -138,9 +138,9 @@ module.exports = function (format, themeSettings, handlebars, options) {
         case 'linkElements':
 
             const formattedFonts = _.mapValues(parsedFonts, function (value, key) {
-                if (options.globals && options.state) {
-                    fontProviders[key].generateResourceHints(options.globals, options.state, value, options.fontDisplay);
-                }
+                // if (options.globals && options.state) {
+                fontProviders[key].generateResourceHints(options.globals, value, options.fontDisplay);
+                // }
                 return fontProviders[key].buildLink(value, options.fontDisplay);
             });
             return new handlebars.SafeString(_.values(formattedFonts).join(''));

--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -138,9 +138,7 @@ module.exports = function (format, themeSettings, handlebars, options) {
         case 'linkElements':
 
             const formattedFonts = _.mapValues(parsedFonts, function (value, key) {
-                // if (options.globals && options.state) {
                 fontProviders[key].generateResourceHints(options.globals, value, options.fontDisplay);
-                // }
                 return fontProviders[key].buildLink(value, options.fontDisplay);
             });
             return new handlebars.SafeString(_.values(formattedFonts).join(''));

--- a/helpers/lib/resourceHints.js
+++ b/helpers/lib/resourceHints.js
@@ -12,7 +12,8 @@ const resourceHintStates = [preloadResourceHintState, preconnectResourceHintStat
 const resourceHintFontType = 'font';
 const resourceHintStyleType = 'style';
 const resourceHintScriptType = 'script';
-const resourceHintTypes = [resourceHintStyleType, resourceHintFontType, resourceHintScriptType];
+const resourceHintDocumentType = 'document';
+const resourceHintTypes = [resourceHintStyleType, resourceHintFontType, resourceHintScriptType, resourceHintDocumentType];
 
 const noCors = 'no';
 const anonymousCors = 'anonymous';
@@ -21,11 +22,11 @@ const allowedCors = [noCors, anonymousCors, useCredentialsCors];
 
 /**
  * @param {string} path - The uri to the resource.
- * @param {string} state - any of [preload, preconnect, prerender, dns-prefetch]
- * @param {string} type? - any of [style, font, script] If an invalid value is provided, property won't be included
- * @param {string} cors? - any of [no, anonymous, use-credentials] defaults to no when no value is provided
+ * @param {string} rel - any of [preload, preconnect, prerender, dns-prefetch]
+ * @param {string} type? - (as attr in HTML link tag) any of [style, font, script,document] If an invalid value is provided, property won't be included
+ * @param {string} cors? - (crossorigin attr in HTML tag) any of [no, anonymous, use-credentials] defaults to no when no value is provided
  */
-function addResourceHint(globals, path, state, type, cors) {
+function addResourceHint(globals, path, rel, type, cors) {
 
     if (!utils.isString(path)) {
         throw new Error('Invalid path provided. path should be a non empty string');
@@ -37,7 +38,7 @@ function addResourceHint(globals, path, state, type, cors) {
         throw new Error(`Invalid value (resource URL) provided: ${path}`)
     }
 
-    if (!utils.isString(state) || !resourceHintStates.includes(state)) {
+    if (!utils.isString(rel) || !resourceHintStates.includes(rel)) {
         throw new Error(`resourceHint attribute received invalid value. Valid values are: ${resourceHintStates}`);
     }
 
@@ -54,7 +55,7 @@ function addResourceHint(globals, path, state, type, cors) {
         return;
     }
 
-    let hint = {src: path, state};
+    let hint = {src: path, state: rel};
 
     if (utils.isString(type) && resourceHintTypes.includes(type)) {
         hint.type = type;

--- a/helpers/resourceHints.js
+++ b/helpers/resourceHints.js
@@ -44,9 +44,9 @@ const factory = globals => {
             return addResourceHint(
                 globals,
                 host,
-                resourceHintAllowedStates.dnsPrefetchResourceHintState,
+                resourceHintAllowedStates.preconnectResourceHintState,
                 resourceHintAllowedTypes.resourceHintFontType,
-                resourceHintAllowedCors.noCors
+                resourceHintAllowedCors.anonymousCors
             );
         });
 

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const buildCDNHelper = require('./lib/cdnify');
-const {addResourceHint, resourceHintAllowedTypes, resourceHintAllowedCors} = require('./lib/resourceHints');
+const {
+    addResourceHint,
+    resourceHintAllowedTypes,
+    resourceHintAllowedCors,
+    defaultResourceHintState
+} = require('./lib/resourceHints');
+const {isString} = require('handlebars-utils');
 
 const factory = globals => {
     const cdnify = buildCDNHelper(globals);
@@ -18,18 +24,15 @@ const factory = globals => {
             : assetPath;
 
         let url = cdnify(path);
-
-
-        if (options.hash && options.hash.resourceHint) {
+        if (isString(url)) {
             const cross = options.hash.crossorigin || resourceHintAllowedCors.noCors;
             url = addResourceHint(
                 globals,
                 url,
-                options.hash.resourceHint,
+                defaultResourceHintState,
                 resourceHintAllowedTypes.resourceHintStyleType,
                 cross
             );
-            delete options.hash.resourceHint;
         }
 
         const attrs = Object.assign({rel: 'stylesheet'}, options.hash);

--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const buildCDNHelper = require('./lib/cdnify');
-const {addResourceHint, resourceHintAllowedTypes} = require('./lib/resourceHints');
+const {addResourceHint, resourceHintAllowedTypes, resourceHintAllowedCors} = require('./lib/resourceHints');
 
 const factory = globals => {
     const cdnify = buildCDNHelper(globals);
@@ -20,12 +20,14 @@ const factory = globals => {
         let url = cdnify(path);
 
 
-        if (options.hash.resourceHint) {
+        if (options.hash && options.hash.resourceHint) {
+            const cross = options.hash.crossorigin || resourceHintAllowedCors.noCors;
             url = addResourceHint(
                 globals,
                 url,
                 options.hash.resourceHint,
-                resourceHintAllowedTypes.resourceHintStyleType
+                resourceHintAllowedTypes.resourceHintStyleType,
+                cross
             );
             delete options.hash.resourceHint;
         }

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -29,23 +29,42 @@ describe('cdn helper', function () {
         const runTestCases = testRunner({context, renderer});
         runTestCases([
             {
-                input: '{{cdn "assets/css/style.css" resourceHint="preload"}}',
+                input: '{{cdn "assets/css/style.css" resourceHint="preload" as="style"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.css',
             },
             {
-                input: '{{cdn "/assets/css/style.modal.css" resourceHint="preconnect"}}',
+                input: '{{cdn "/assets/css/style.modal.css" resourceHint="preconnect" as="style"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.modal.css',
             },
             {
-                input: '{{cdn "/assets/css/style.modal.css" }}',
+                input: '{{cdn "/assets/css/style.modal.css" as="style"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.modal.css',
             }
         ], () => {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(2);
             hints.forEach(hint => {
-                expect(hint.type).to.not.exist();
                 expect(hint.state).to.satisfy((state) => state === 'preload' || state === 'preconnect');
+                expect(hint.type).to.equals("style")
+            });
+            done();
+        });
+    });
+
+    it('should render the css cdn url and produce resource hint without as/type attribute', function (done) {
+        const renderer = buildRenderer(siteSettings, themeSettings, {}, hbVersion);
+        const runTestCases = testRunner({context, renderer});
+        runTestCases([
+            {
+                input: '{{cdn "assets/css/style.css" resourceHint="preload" as="should-not-be-included"}}',
+                output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.css',
+            }
+        ], () => {
+            const hints = renderer.getResourceHints();
+            expect(hints).to.have.length(1);
+            hints.forEach(hint => {
+                expect(hint.state).to.equals('preload');
+                expect(hint.type).to.not.exist();
             });
             done();
         });

--- a/spec/helpers/earlyHint.js
+++ b/spec/helpers/earlyHint.js
@@ -11,10 +11,10 @@ const {
     resourceHintAllowedCors
 } = require("../../helpers/lib/resourceHints");
 
-function template(path, state, type, cors) {
-    cors = cors ? `cors="${cors}"` : '';
-    type = cors ? `as="${type}"` : '';
-    return `{{ earlyHint "${path}" "${state}" ${type} ${cors} }}`;
+function template(href, rel, type, cors) {
+    cors = cors ? `crossorigin="${cors}"` : '';
+    type = type ? `as="${type}"` : '';
+    return `{{ earlyHint "${href}" "${rel}" ${type} ${cors} }}`;
 }
 
 function randommer(items) {

--- a/spec/helpers/earlyHint.js
+++ b/spec/helpers/earlyHint.js
@@ -6,13 +6,15 @@ const Lab = require('lab'),
 const {buildRenderer, testRunner} = require("../spec-helpers");
 const {expect} = require("code");
 const {
+    resourceHintAllowedTypes,
     resourceHintAllowedStates,
     resourceHintAllowedCors
 } = require("../../helpers/lib/resourceHints");
 
-function template(path, state, cors) {
+function template(path, state, type, cors) {
     cors = cors ? `cors="${cors}"` : '';
-    return `{{ earlyHint "${path}" "${state}" ${cors} }}`;
+    type = cors ? `as="${type}"` : '';
+    return `{{ earlyHint "${path}" "${state}" ${type} ${cors} }}`;
 }
 
 function randommer(items) {
@@ -20,6 +22,7 @@ function randommer(items) {
 }
 
 const randomHintState = randommer(Object.values(resourceHintAllowedStates));
+const randomHintType = randommer(Object.values(resourceHintAllowedTypes));
 const randomCors = randommer(Object.values(resourceHintAllowedCors));
 
 let renderer, runTests;
@@ -52,8 +55,9 @@ describe('earlyHint', () => {
     it('should create a resource hint with all the properties', done => {
         const path = '/asset/theme.css'
         const state = randomHintState();
+        const type = randomHintType();
         const cors = randomCors();
-        const input = template(path, state, cors);
+        const input = template(path, state, type, cors);
         runTests([
             {
                 input,
@@ -62,7 +66,7 @@ describe('earlyHint', () => {
         ], () => {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(1);
-            expect(hints[0]).to.equals({src: path, state, cors});
+            expect(hints[0]).to.equals({src: path, state, type, cors});
             done();
         });
     });

--- a/spec/helpers/getFontsCollection.js
+++ b/spec/helpers/getFontsCollection.js
@@ -24,7 +24,7 @@ describe('getFontsCollection', function () {
         const href = "https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700%7CKarla:700%7CLora:400%7CVolkron:%7CDroid:400,700%7CCrimson+Text:400,700&display=swap";
         runTestCases([
             {
-                input: '{{getFontsCollection resourceHint="preload"}}',
+                input: '{{getFontsCollection}}',
                 output: `<link href="${href}" rel="stylesheet">`,
             },
         ], () => {
@@ -88,13 +88,13 @@ describe('getFontsCollection', function () {
         const runTestCases = testRunner({renderer});
         runTestCases([
             {
-                input: '{{getFontsCollection resourceHint="preconnect"}}',
+                input: '{{getFontsCollection}}',
                 output: '<link href="https://fonts.googleapis.com/css?family=Open+Sans:&display=swap" rel="stylesheet">',
             },
         ], () => {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(1);
-            expect(hints[0].state).to.equals(resourceHintAllowedStates.preconnectResourceHintState);
+            expect(hints[0].state).to.equals(resourceHintAllowedStates.preloadResourceHintState);
             done();
         });
     });

--- a/spec/helpers/resourceHints.js
+++ b/spec/helpers/resourceHints.js
@@ -36,9 +36,9 @@ describe('resourceHints', function () {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(2);
             hints.forEach(hint => {
-                expect(hint.cors).to.equals(resourceHintAllowedCors.noCors);
+                expect(hint.cors).to.equals(resourceHintAllowedCors.anonymousCors);
                 expect(hint.type).to.equals(resourceHintAllowedTypes.resourceHintFontType);
-                expect(hint.state).to.equals(resourceHintAllowedStates.dnsPrefetchResourceHintState);
+                expect(hint.state).to.equals(resourceHintAllowedStates.preconnectResourceHintState);
             });
             done();
         });

--- a/spec/helpers/stylesheet.js
+++ b/spec/helpers/stylesheet.js
@@ -21,7 +21,7 @@ describe('stylesheet helper', () => {
         const runner = testRunner({renderer});
         runner([
             {
-                input: '{{{stylesheet "assets/css/style.css" resourceHint="preload" crossorigin="anonymous"}}}',
+                input: '{{{stylesheet "assets/css/style.css" crossorigin="anonymous"}}}',
                 output: '<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/123/css/style-xyz.css" rel="stylesheet" crossorigin="anonymous">',
             },
         ], () => {
@@ -68,7 +68,7 @@ describe('stylesheet helper', () => {
         const src = '/assets/css/style-foo.css';
         runner([
             {
-                input: '{{{stylesheet "assets/css/style.css" resourceHint="preconnect"}}}',
+                input: '{{{stylesheet "assets/css/style.css" }}}',
                 output: `<link data-stencil-stylesheet href="${src}" rel="stylesheet">`,
                 siteSettings: siteSettings,
             },
@@ -77,7 +77,7 @@ describe('stylesheet helper', () => {
             expect(hints.length).to.equals(1);
             const hint = hints[0];
             expect(hint.src).to.equals(src);
-            expect(hint.state).to.equals('preconnect');
+            expect(hint.state).to.equals('preload');
             expect(hint.cors).to.equals(noCors);
             done();
         });

--- a/spec/helpers/stylesheet.js
+++ b/spec/helpers/stylesheet.js
@@ -5,6 +5,7 @@ const Lab = require('lab'),
 const {buildRenderer, testRunner} = require("../spec-helpers");
 const {expect} = require("code");
 const {resourceHintStyleType} = require("../../helpers/lib/resourceHints").resourceHintAllowedTypes;
+const {anonymousCors, noCors} = require("../../helpers/lib/resourceHints").resourceHintAllowedCors;
 
 describe('stylesheet helper', () => {
     const siteSettings = {
@@ -20,16 +21,17 @@ describe('stylesheet helper', () => {
         const runner = testRunner({renderer});
         runner([
             {
-                input: '{{{stylesheet "assets/css/style.css" resourceHint="preload"}}}',
-                output: '<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/123/css/style-xyz.css" rel="stylesheet">',
+                input: '{{{stylesheet "assets/css/style.css" resourceHint="preload" crossorigin="anonymous"}}}',
+                output: '<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/123/css/style-xyz.css" rel="stylesheet" crossorigin="anonymous">',
             },
         ], () => {
             const hints = renderer.getResourceHints();
             expect(hints.length).to.equals(1);
-            hints.forEach(({src, type, state}) => {
+            hints.forEach(({src, type, state, cors}) => {
                 expect(src).to.startWith(siteSettings.cdn_url);
                 expect(type).to.equals(resourceHintStyleType);
                 expect(state).to.equals('preload');
+                expect(cors).to.equals(anonymousCors);
             });
             done();
         });
@@ -76,6 +78,7 @@ describe('stylesheet helper', () => {
             const hint = hints[0];
             expect(hint.src).to.equals(src);
             expect(hint.state).to.equals('preconnect');
+            expect(hint.cors).to.equals(noCors);
             done();
         });
     });


### PR DESCRIPTION
## What? Why?

- earlyHint helper now support as attribute
- cdn helper now support as attribute for early hint
- resourceHints helper, hints' cors is now anonymous to reflect the link tag that is built, also, rel now is preconnect
- renaming addResourceHint params to better reflect parity with HTLM link tag - stylesheet helper preload hint support crossorigin attr (defaulting to "no")

## How was it tested?

- [x] unit tests

----

cc @bigcommerce/storefront-team
