### PR TITLE
chore: release 5.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 5.1.6
+
+- ref: STRF-10124 Clean up handlebars dependencies ([#209])[https://github.com/bigcommerce/paper-handlebars/pull/209]
+
 ## 5.1.5
 
 - feat: preload hints generation, `as` attribute properly implemented

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- ref: STRF-10124 Clean up handlebars dependencies ([#209])[https://github.com/bigcommerce/paper-handlebars/pull/209]

----

cc @bigcommerce/storefront-team
