### PR TITLE
fix: STRF-10157 Fix build job: npm ci -> npm i

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm i
 
       - name: Verify Github PR Title
-        run: echo ${{ github.event.pull_request.title }} | npx commitlint
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
 
       - name: Verify Git Commit Name 
         run: git log -1 --pretty=format:"%s" |  npx commitlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-      - run: npm ci
+      - run: npm i
       - run: npm run build
       - name: Check Git Commit name
         run: git log -1 --pretty=format:"%s" |  npx commitlint


### PR DESCRIPTION
## What? Why?

As we don't publish package-lock.json, we can't use `npm ci` in Github Actions


----

cc @bigcommerce/storefront-team
