### PR TITLE
fix: STRF-10157 Fix semantic release: added missing dependency

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,7 @@
 {
     "branches": ["master"],
     "plugins": [
+      "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       ["@semantic-release/github", {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
     "@semantic-release/changelog": "^6.0.1",
+    "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.6",


### PR DESCRIPTION
## What? Why?

@semantic-release/exec plugin was having missing dependency

## How was it tested?

<img width="990" alt="Screenshot 2022-10-20 at 18 32 32" src="https://user-images.githubusercontent.com/68893868/197006536-6cd67a0d-233e-4370-8da2-9311b566962d.png">

----

cc @bigcommerce/storefront-team
