### PR TITLE
fix: STRF-10157 Fix adding assets to Github Release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -12,7 +12,7 @@
       "@semantic-release/npm",
       [
         "semantic-release-github-pullrequest", {
-          "assets": ["CHANGELOG.md", "package.json", "dist"],
+          "assets": ["CHANGELOG.md", "package.json", "dist/**"],
           "baseRef": "master"
         }
       ],


### PR DESCRIPTION
## What? Why?

Folders should use glob pattern according to [documentation](https://github.com/asbiin/semantic-release-github-pullrequest#assets) 


----

cc @bigcommerce/storefront-team
