### PR TITLE
fix: STRF-10157 Fix github release assets files

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,13 +6,14 @@
       "@semantic-release/changelog",
       ["@semantic-release/github", {
         "assets": [
-          {"path": "dist/*.{js,ts,map}"}
+          {"path": "dist/blackbird-handlebars.js", "label": "helpers.js"},
+          {"path": "dist/index.js", "label": "index.js"}
         ]
       }],
       "@semantic-release/npm",
       [
         "semantic-release-github-pullrequest", {
-          "assets": ["CHANGELOG.md", "package.json", "dist/**"],
+          "assets": ["CHANGELOG.md", "package.json"],
           "baseRef": "master"
         }
       ],


### PR DESCRIPTION
## What? Why?

Looks like we don't need dist folder in the PR, only in the github release

----

cc @bigcommerce/storefront-team
