### PR TITLE
fix: STRF-10157 Fix sending event data to paper repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,5 @@ jobs:
         run: npm config list && npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GA_USERNAME: ${{ secrets.PAT_USERNAME }}
+          GA_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -6,8 +6,7 @@
       "@semantic-release/changelog",
       ["@semantic-release/github", {
         "assets": [
-          {"path": "dist/blackbird-handlebars.js", "label": "helpers.js"},
-          {"path": "dist/index.js", "label": "index.js"}
+          {"path": "dist/blackbird-handlebars.js", "label": "helpers.js"}
         ]
       }],
       "@semantic-release/npm",
@@ -19,7 +18,7 @@
       ],
       [
         "@semantic-release/exec", {
-          "publishCmd": "curl -XPOST -u \"${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}\" -H \"Accept: application/vnd.github.everest-preview+json\" -H \"Content-Type: application/json\" https://api.github.com/repos/bigcommerce/paper/dispatches --data '{\"event_type\": \"bump_hbs\", \"version\": \"${nextRelease.version}\", \"notes\": \"${nextRelease.notes}\"}"
+          "publishCmd": "./publish.sh ${nextRelease.version} ${nextRelease.notes}"
         }
       ]
     ]

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,1 @@
+curl -XPOST -u "$GA_USERNAME:$GA_TOKEN" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/bigcommerce/paper/dispatches --data '{"event_type": "bump_hbs", "version": "'$1'", "notes": "'$2'"}'


### PR DESCRIPTION
## What? Why?

Refactor how sending event data is being proceed:
1. semantic release handles knowledge of the next release and notes.
2. it sends that data to bash script via cli args
3. bash script access env vars (secrets) and cli args to send event data throught curl (github api)

----

cc @bigcommerce/storefront-team
