### PR TITLE
fix: STRF-10120 getFontsCollection helper hint should be of type style not font

### DIFF
--- a/helpers/lib/fonts.js
+++ b/helpers/lib/fonts.js
@@ -86,7 +86,7 @@ const fontProviders = {
                 globals,
                 path,
                 defaultResourceHintState,
-                resourceHintAllowedTypes.resourceHintFontType
+                resourceHintAllowedTypes.resourceHintStyleType
             );
         }
     },

--- a/spec/helpers/getFontsCollection.js
+++ b/spec/helpers/getFontsCollection.js
@@ -32,7 +32,7 @@ describe('getFontsCollection', function () {
             expect(hints).to.have.length(1);
             expect(hints[0].src).to.equals(href);
             expect(hints[0].state).to.equals(resourceHintAllowedStates.preloadResourceHintState);
-            expect(hints[0].type).to.equals(resourceHintAllowedTypes.resourceHintFontType);
+            expect(hints[0].type).to.equals(resourceHintAllowedTypes.resourceHintStyleType);
             done();
         });
     });


### PR DESCRIPTION
## What? Why?

`getFontsCollection` helper hint should be of type `style` not `font`

## How was it tested?

- [x] unit tests

----

cc @bigcommerce/storefront-team
