### PR TITLE
fix: STRF-10175 Allow only strings passed to partial and block helpers

### DIFF
--- a/helpers/block.js
+++ b/helpers/block.js
@@ -1,7 +1,15 @@
 'use strict';
 
+const utils = require('./3p/utils');
+const common = require('./lib/common.js');
+
 const factory = globals => {
     return function(name) {
+        name = common.unwrapIfSafeString(globals.handlebars, name);
+        if (!utils.isString(name)) {
+            globals.getLogger().info("Non-string passed to block helper");
+            return '';
+        }
         const options = arguments[arguments.length - 1];
 
         /* Look for partial by name. */

--- a/helpers/partial.js
+++ b/helpers/partial.js
@@ -1,7 +1,15 @@
 'use strict';
 
+const utils = require('./3p/utils');
+const common = require('./lib/common.js');
+
 const factory = globals => {
     return function(name) {
+        name = common.unwrapIfSafeString(globals.handlebars, name);
+        if (!utils.isString(name)) {
+            globals.getLogger().info("Non-string passed to partial helper");
+            return '';
+        }
         const options = arguments[arguments.length - 1];
         globals.handlebars.registerPartial(name, options.fn);
     };

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ class HandlebarsRenderer {
             getThemeSettings: this.getThemeSettings.bind(this),
             getTranslator: this.getTranslator.bind(this),
             getContent: this.getContent.bind(this),
+            getLogger: this.getLogger.bind(this),
             storage: {}, // global storage used by helpers to keep state
             resourceHints: []
         };
@@ -167,6 +168,15 @@ class HandlebarsRenderer {
     getContent() {
         return this._contentRegions;
     };
+
+    /**
+     * Get logger provided to the library
+     *
+     * @param {Object} logger
+     */
+    getLogger() {
+        return this.logger;
+    }
 
     /**
      * Add templates to the active set of partials. The templates can either be raw

--- a/spec/helpers/block.js
+++ b/spec/helpers/block.js
@@ -4,7 +4,7 @@ const lab = exports.lab = Lab.script();
 const describe = lab.experiment;
 const expect = Code.expect;
 const it = lab.it;
-const render = require('../spec-helpers').render;
+const { render } = require('../spec-helpers');
 
 describe('partial and block helpers', function () {
     it('should insert partial into the corresponding block', function (done) {
@@ -43,6 +43,34 @@ describe('partial and block helpers', function () {
 
         render('template', {}, {}, {}, templates).then(result => {
             expect(result).to.be.equal('Hello');
+            done();
+        });
+    });
+
+    it('should successfully render template', function (done) {
+        const templateContent = "some-content";
+        const templates = {
+            "layout/base": templateContent,
+            template: `{{#JSONparse '{"layout/base":{}}'}}{{#partial this}}{{/partial}}{{/JSONparse}}{{>layout/base}}`,
+        };
+        render('template', {}, {}, {}, templates).then(result => {
+            expect(result).to.be.equal(templateContent);
+            done();
+        });
+    });
+
+    it('should successfully render template with context', function (done) {
+        const templateContent = "Hello, world!";
+        const templates = {
+            template: `{{#partial "base"}}Hello, world!{{/partial}}{{#partial notPartials}}{{/partial}}{{> base}}`,
+        };
+        const context  = {
+            notPartials: {
+                "base": {}
+            }
+        }
+        render('template', context, {}, {}, templates).then(result => {
+            expect(result).to.be.equal(templateContent);
             done();
         });
     });

--- a/spec/helpers/getObject.js
+++ b/spec/helpers/getObject.js
@@ -33,16 +33,15 @@ describe('getObject helper', function () {
         ], done);
     });
 
-    // uncomment when 3rd-party version is replaced
-    // it('does not access prototype props', function (done) {
-    //     context.obj.__proto__ = {x: 'yz'};
-    //     runTestCases([
-    //         {
-    //             input: `{{#with (getObject "x" obj)}}{{x}}{{/with}}`,
-    //             output: ``,
-    //         },
-    //     ], done);
-    // });
+    it('does not access prototype props', function (done) {
+        context.obj.__proto__ = {x: 'yz'};
+        runTestCases([
+            {
+                input: `{{#with (getObject "x" obj)}}{{x}}{{/with}}`,
+                output: ``,
+            },
+        ], done);
+    });
 
     it('accepts SafeString paths', (done) => {
         runTestCases([


### PR DESCRIPTION
## What? Why?

More context: https://bigcommercecloud.atlassian.net/browse/STRF-10175

## How was it tested?

`npm test`

----

cc @bigcommerce/storefront-team
