### PR TITLE
fix: STRF-10198 Accept only strings for lang helper output

### DIFF
--- a/helpers/lang.js
+++ b/helpers/lang.js
@@ -4,7 +4,13 @@ const factory = globals => {
     return function(translationKey) {
         const options = arguments[arguments.length - 1];
         const translator = globals.getTranslator();
-        return translator ? translator.translate(translationKey, options.hash) : '';
+        if (translator) {
+            const result = translator.translate(translationKey, options.hash);
+            if (typeof result === 'string') {
+                return result;
+            }
+        }
+        return ''
     };
 };
 

--- a/spec/helpers/lang.js
+++ b/spec/helpers/lang.js
@@ -16,6 +16,7 @@ describe('lang helper', () => {
     beforeEach(done => {
         context = {
             name: 'BigCommerce',
+            test: {},
         };
 
         renderer = buildRenderer();
@@ -44,6 +45,20 @@ describe('lang helper', () => {
         runTestCases([
             {
                 input: '{{lang "powered_by" name=name}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('should return an empty string if translastor returns an object', done => {
+        renderer.setTranslator({
+            getLocale: () => 'en',
+            translate: (key, params) => params.test,
+        });
+
+        runTestCases([
+            {
+                input: '{{lang "some_key" name=test}}',
                 output: '',
             },
         ], done);


### PR DESCRIPTION
## What? Why?

Fix lang helper output to have returned only strings

## How was it tested?

npm test, cdvm

----

cc @bigcommerce/storefront-team
