### PR TITLE
fix: STRF-10180 Improve titleize and length helpers edge cases

### DIFF
--- a/helpers/3p/collection.js
+++ b/helpers/3p/collection.js
@@ -85,7 +85,7 @@ helpers.iterate = function(context, options) {
  */
 
 helpers.length = function(value) {
-  if (utils.isUndefined(value)) {return '';}
+  if (!value || utils.isUndefined(value)) {return '';}
   if (typeof value === 'string' && /[[]/.test(value)) {
     value = utils.tryParse(value) || [];
   }

--- a/helpers/3p/string.js
+++ b/helpers/3p/string.js
@@ -414,6 +414,9 @@ helpers.titleize = function(str) {
   if (str && typeof str === 'string') {
     var title = str.replace(/[ \-_]+/g, ' ');
     var words = title.match(/\w+/g);
+    if (!words) {
+      return str;
+    }
     var len = words.length;
     var res = [];
     var i = 0;

--- a/spec/helpers/3p/collection.js
+++ b/spec/helpers/3p/collection.js
@@ -105,6 +105,12 @@ describe('collection', function() {
       done();
     });
 
+    it('should return empty strig when the value is null.', function(done) {
+      var fn = hbs.compile('{{length foo}}');
+      expect(fn({foo: null})).to.equal('');
+      done();
+    });
+
     it('should return the length of a string.', function(done) {
       var fn = hbs.compile('{{length "foo"}}');
       expect(fn(context)).to.equal('3');

--- a/spec/helpers/3p/string.js
+++ b/spec/helpers/3p/string.js
@@ -303,6 +303,13 @@ describe('string', function() {
       expect(fn()).to.equal('');
       done();
     });
+  
+    it('should return unchanged input string if string has only non-word characters', function(done) {
+      var fn = hbs.compile('{{titleize ",!"}}');
+      expect(fn()).to.equal(',!');
+      done();
+    });
+  
     it('should return the string in title case.', function(done) {
       var fn = hbs.compile('{{titleize "Bender-should-Not-be-allowed_on_Tv"}}');
       expect(fn()).to.equal('Bender Should Not Be Allowed On Tv');


### PR DESCRIPTION
## What? Why?

1. `titleize` was erroring providing non-words character
2. `length` failed on null

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
