### PR TITLE
feat: Add JSONparseSafe helper

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -30,6 +30,7 @@ const helpersList = [
     'join',
     'jsContext',
     'json',
+    'jsonParseSafe',
     'lang',
     'langJson',
     'limit',

--- a/helpers/jsonParseSafe.js
+++ b/helpers/jsonParseSafe.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function factory(globals) {
+  return function (value) {
+    const options = arguments[arguments.length - 1];
+
+    try {
+      return options.fn(JSON.parse(value));
+    } catch (err) {
+      return options.inverse(this);
+    }
+  };
+}
+
+module.exports = [{
+  name: 'JSONparseSafe',
+  factory: factory,
+}];

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -146,6 +146,7 @@ describe('helper registration', () => {
             'hasOwn',
             'isObject',
             'merge',
+            'JSONparseSafe',
             'JSONparse',
             'JSONstringify',
             'camelcase',

--- a/spec/helpers/jsonParseSafe.js
+++ b/spec/helpers/jsonParseSafe.js
@@ -1,0 +1,28 @@
+const { describe, it } = exports.lab = require('lab').script();
+
+const { testRunner } = require('../spec-helpers');
+
+describe('JSONParseSafe helper', () => {
+    const context = {
+        jsonString: '{"name": "John"}',
+        string: 'John Doe',
+    };
+    const runTestCases = testRunner({context});
+
+    it('should have the same behavior as the original if helper', done => {
+        runTestCases([
+            {
+                input: '{{#JSONparseSafe string}}{{name}}{{/JSONparseSafe}}',
+                output: '',
+            },
+            {
+                input: '{{#JSONparseSafe jsonString}}{{name}}{{/JSONparseSafe}}',
+                output: 'John',
+            },
+            {
+                input: '{{#JSONparseSafe string}}{{name}}{{else}}{{string}}{{/JSONparseSafe}}',
+                output: 'John Doe',
+            },
+        ], done);
+    });
+});

--- a/spec/helpers/jsonParseSafe.js
+++ b/spec/helpers/jsonParseSafe.js
@@ -9,16 +9,26 @@ describe('JSONParseSafe helper', () => {
     };
     const runTestCases = testRunner({context});
 
-    it('should have the same behavior as the original if helper', done => {
+    it('should execute the main instruction', done => {
+        runTestCases([
+            {
+                input: '{{#JSONparseSafe jsonString}}{{name}}{{/JSONparseSafe}}',
+                output: 'John',
+            },
+        ], done);
+    });
+
+    it('should skip the main instruction if variable is non-json', done => {
         runTestCases([
             {
                 input: '{{#JSONparseSafe string}}{{name}}{{/JSONparseSafe}}',
                 output: '',
             },
-            {
-                input: '{{#JSONparseSafe jsonString}}{{name}}{{/JSONparseSafe}}',
-                output: 'John',
-            },
+        ], done);
+    });
+
+    it('should execute the else instruction if variable is non-json', done => {
+        runTestCases([
             {
                 input: '{{#JSONparseSafe string}}{{name}}{{else}}{{string}}{{/JSONparseSafe}}',
                 output: 'John Doe',


### PR DESCRIPTION
## What? Why?
We have the JSONParse helper which parse JSON and return an object:
```
{{#JSONparse jsonString}}
  {{name}}
{{/JSONparse}}
```
Helper works fine until non-json comes to parse. In this case it will break a page because it always expects syntactically correct JSON.

We faced with such case when parameter can be string or json and need to have a helper that can parse it safely.
According to required, we want to add a new `JSONparseSafe` helper:
```
{{#JSONparseSafe jsonString}}
  {{name}}
{{/JSONparseSafe}}

{{#JSONparseSafe jsonString}}
  {{name}}
{{else}}
  {{string}}
{{/JSONparseSafe}}
```
So, the helper try to parse passed parameter then
  - if succeeded - return an object
  - if failure - do nothing
  - if failure and we have else instruction - do else instruction
  
If you need more information please reach me

## How was it tested?
Tested manually / Unit tests

----

cc @bigcommerce/storefront-team
