### PR TITLE
Remove: !utils.isString(newSubstr) or add keyword

### DIFF
--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -13,8 +13,6 @@ const factory = globals => {
             throw new TypeError("Invalid query parameter string passed to strReplace");
         } else if (!utils.isString(substr)) {
             throw new TypeError("Invalid query paramter substring passed to strReplace");
-        } else if (!utils.isString(newSubstr)) {
-            throw new TypeError("Invalid query parameter new substring passed to strReplace");
         }
 
         if (typeof iteration !== 'number') {


### PR DESCRIPTION
## What? Why?
Often times there needs to be a simple key replacement such as this:  
```<a href='{{{strReplace settings.phone_number "-" ""}}}'>{{settings.phone_number}}</a> ```

## How was it tested?
Adding either a null keyword or removing the if completely would fix this issue. I can see it being added to `substr` but I don't entirely see why it's added to the `newSubstr`

----

cc @bigcommerce/storefront-team
