### PR TITLE
fix: STRF-10494 last and first helpers works with strings

### DIFF
--- a/helpers/3p/array.js
+++ b/helpers/3p/array.js
@@ -161,7 +161,8 @@ helpers.first = function(array, n) {
 
   if (utils.isString(array)) {
     const chars = array.split('');
-    return arrayAlt(chars, n);
+    const result = arrayAlt(chars, n);
+    return Array.isArray(result) ? result.join('') : result;
   }
 
   return [];
@@ -308,8 +309,8 @@ helpers.last = function(array, n) {
 
   function stringAlt(str, n) {
     const chars = str.split('');
-    const arr = arrayAlt(chars, n);
-    return arr.join('');
+    const result = arrayAlt(chars, n);
+    return Array.isArray(result) ? result.join('') : result;
   }
 
   if (Array.isArray(array)) {

--- a/spec/helpers/3p/first.js
+++ b/spec/helpers/3p/first.js
@@ -1,0 +1,85 @@
+const Lab = require('lab'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    it = lab.it;
+const {testRunner} = require("../../spec-helpers");
+
+describe('first', () => {
+    describe('string', () => {
+
+        const context = {
+            smallString: 'abc',
+            empty: '',
+            myString: 'BigCommerce'
+        };
+
+        const runner = testRunner({context});
+
+        it('should extract the first char when no "n" is given.', done => {
+            runner([{
+                input: '{{first myString}}',
+                output: 'B'
+            }], done);
+        });
+
+        it('should return the whole string when "n" is bigger that string size', done => {
+            runner([{
+                input: '{{first smallString 5}}',
+                output: context.smallString
+            }], done);
+        });
+
+        it('should return the expected string', done => {
+            runner([{
+                input: '{{first myString 3}}',
+                output: 'Big'
+            }], done);
+        });
+
+        it('should return empty string when empty string is provided', done => {
+            runner([{
+                input: '{{first empty 3}}',
+                output: ''
+            }], done);
+        });
+    });
+
+    describe('array', () => {
+
+        const context = {
+            small: [1,2,3],
+            empty:[],
+            arrayYay: [1,2,3,4,5,6,7,8,9,0]
+        };
+
+        const runner = testRunner({context});
+
+        it('should extract the first elem when no "n" is given.', done => {
+            runner([{
+                input: '{{first arrayYay}}',
+                output: '1'
+            }], done);
+        });
+
+        it('should return the whole array when "n" is bigger that array size', done => {
+            runner([{
+                input: '{{first small 5}}',
+                output: context.small.join()
+            }], done);
+        });
+
+        it('should return the expected elems', done => {
+            runner([{
+                input: '{{first arrayYay 3}}',
+                output: [1,2,3].join()
+            }], done);
+        });
+
+        it('should return empty string when empty array is provided', done => {
+            runner([{
+                input: '{{first empty 3}}',
+                output: ''
+            }], done);
+        });
+    });
+});

--- a/spec/helpers/3p/last.js
+++ b/spec/helpers/3p/last.js
@@ -1,0 +1,85 @@
+const Lab = require('lab'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    it = lab.it;
+const {testRunner} = require("../../spec-helpers");
+
+describe('last', () => {
+    describe('string', () => {
+
+        const context = {
+            smallString: 'abc',
+            empty: '',
+            myString: 'BigCommerce'
+        };
+
+        const runner = testRunner({context});
+
+        it('should extract the last char when no "n" is given.', done => {
+            runner([{
+                input: '{{last myString}}',
+                output: 'e'
+            }], done);
+        });
+
+        it('should return the whole string when "n" is bigger that string size', done => {
+            runner([{
+                input: '{{last smallString 5}}',
+                output: context.smallString
+            }], done);
+        });
+
+        it('should return the expected string', done => {
+            runner([{
+                input: '{{last myString 3}}',
+                output: 'rce'
+            }], done);
+        });
+
+        it('should return empty string when empty string is provided', done => {
+            runner([{
+                input: '{{last empty 3}}',
+                output: ''
+            }], done);
+        });
+    });
+
+    describe('array', () => {
+
+        const context = {
+            small: [1, 2, 3],
+            empty: [],
+            arrayYay: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+        };
+
+        const runner = testRunner({context});
+
+        it('should extract the last elem when no "n" is given.', done => {
+            runner([{
+                input: '{{last arrayYay}}',
+                output: '0'
+            }], done);
+        });
+
+        it('should return the whole array when "n" is bigger that array size', done => {
+            runner([{
+                input: '{{last small 5}}',
+                output: context.small.join()
+            }], done);
+        });
+
+        it('should return the expected elems', done => {
+            runner([{
+                input: '{{last arrayYay 3}}',
+                output: [8, 9, 0].join()
+            }], done);
+        });
+
+        it('should return empty string when empty array is provided', done => {
+            runner([{
+                input: '{{last empty 3}}',
+                output: ''
+            }], done);
+        });
+    });
+});


### PR DESCRIPTION
## What? Why?

while testing in int i found that the following error is thrown

```
FailedPrecondition: arr.join is not a function : TypeError: arr.join is not a function
    at stringAlt (/opt/app/node_modules/@bigcommerce/stencil-paper-handlebars/helpers/3p/array.js:312:16)
```

with the following template:

```html
<div style="background-color:aquamarine;">
    <p style="text-align: center;">
        {{first [1,2,3]}}
    </p>
    <p style="text-align: center;">
        {{first [9,8,7,6,5,4,3,2,1] 3}}
    </p>
    <p style="text-align: center;">
        {{first [1,2,3,4,5,6,7,8,9,0] 15}}
    </p>
    <p style="text-align: center;">
        {{last [1,2,3]}}
    </p>
    <p style="text-align: center;">
        {{last [9,8,7,6,5,4,3,2,1] 8}}
    </p>
    <p style="text-align: center;">
        {{last [1,2,3,4,5,6,7,8,9,0] 15}}
    </p>
</div>

    <div style="background-color: aqua;">
        <p style="text-align: center;">
            {{first "BigCommerce"}}
        </p>
        <p style="text-align: center;">
            {{first "BigCommerce" 3}}
        </p>
        <p style="text-align: center;">
            {{first "BigCommerce" 15}}
        </p>
        <p style="text-align: center;">
            {{last "BigCommerce"}}
        </p>
        <p style="text-align: center;">
            {{last "BigCommerce" 8}}
        </p>
        <p style="text-align: center;">
            {{last "BigCommerce" 15}}
        </p>
    </div>
```

so I'm adding a guard code here.

## How was it tested?

unit test

----

cc @bigcommerce/storefront-team
