### PR TITLE
Allow strings to be replaced with an empty string. Changes within strReplace file

### DIFF
--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -14,7 +14,7 @@ const factory = globals => {
             throw new ValidationError("Invalid query parameter string passed to strReplace");
         } else if (!utils.isString(substr)) {
             throw new ValidationError("Invalid query paramter substring passed to strReplace");
-        } else if (!utils.isString(newSubstr)) {
+        } else if (!utils.isString(newSubstr) && newSubstr !== "") {
             throw new ValidationError("Invalid query parameter new substring passed to strReplace");
         }
 


### PR DESCRIPTION
## What? Why?

Added check for an empty string to be eligible to change the old string.  This feature would allow you to easily manipulate prices within BC templates because you have to strip currency sign commas etc.

## How was it tested?

This feature was tested on the development BigCommerce theme and it works as expected. 

----

cc @bigcommerce/storefront-team
