### PR TITLE
fix: Improve strReplace to remove characters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "node": true,
     "es2017": true // suppport globals (like Promise) up to es2017 (es2018 doesn't have new globals)
   },
+  "ignorePatterns": ["dist/**/*"],
   "rules": {
     "curly": 2,
     "no-eq-null": 2,

--- a/helpers/strReplace.js
+++ b/helpers/strReplace.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('./lib/common.js');
-const utils = require('./3p/utils');
 const { ValidationError } = require('../lib/errors');
 
 const factory = globals => {
@@ -10,11 +9,11 @@ const factory = globals => {
         newSubstr = common.unwrapIfSafeString(globals.handlebars, newSubstr);
         iteration = common.unwrapIfSafeString(globals.handlebars, iteration);
 
-        if (!utils.isString(str)) {
+        if (typeof str !== 'string') {
             throw new ValidationError("Invalid query parameter string passed to strReplace");
-        } else if (!utils.isString(substr)) {
-            throw new ValidationError("Invalid query paramter substring passed to strReplace");
-        } else if (!utils.isString(newSubstr)) {
+        } else if (typeof substr !== 'string') {
+            throw new ValidationError("Invalid query parameter substring passed to strReplace");
+        } else if (typeof newSubstr !== 'string') {
             throw new ValidationError("Invalid query parameter new substring passed to strReplace");
         }
 

--- a/spec/helpers/strReplace.js
+++ b/spec/helpers/strReplace.js
@@ -29,6 +29,15 @@ describe('strReplace helper', function() {
         ], done);
     });
 
+    it('should remove characters from string', function(done) {
+        runTestCases([
+            {
+                input: '{{strReplace "123-45-6789" "-" ""}}',
+                output: '123456789',
+            },
+        ], done);
+    });
+
     it('should replace multiple if given quantity', function(done) {
         runTestCases([
             {


### PR DESCRIPTION
## What? Why?

strReplace helper should be able to replace with empty characters

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
