### PR TITLE
chore: Bump stringz package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "he": "^1.2.0",
     "moment": "^2.29.4",
     "remarkable": "^2.0.1",
-    "stringz": "^0.1.1"
+    "stringz": "2.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",


### PR DESCRIPTION
## What? Why?

`stringz` package version bumped to latest.
Based on the package changelog it seems safe to use the latest version as no braking changes are mentioned. https://github.com/sallar/stringz/blob/master/CHANGELOG.md 

## How was it tested?

- unit tests still passing

----

cc @bigcommerce/storefront-team
