### PR TITLE
fix: This reverts PR #263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [5.7.5](https://github.com/bigcommerce/paper-handlebars/compare/v5.7.4...v5.7.5) (2023-03-29)
-
-### Features
-
-* bump `stringz` dependency version to its latest version ([#261](https://github.com/bigcommerce/paper-handlebars/pull/261)) ([b0ddeca](https://github.com/bigcommerce/paper-handlebars/pull/261/commits/625cda1611a89c14b244f7911cb25a7105a28383))
-
 ## [5.7.4](https://github.com/bigcommerce/paper-handlebars/compare/v5.7.3...v5.7.4) (2023-03-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper-handlebars",
-  "version": "5.7.5",
+  "version": "5.7.4",
   "description": "A paper plugin to render pages using Handlebars.js",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
## What? Why?

I messed up the versions in this package trying to get a new release out.
Good thing is that no new release was pushed out so we can revert the version with no risk.

After going through some GH actions' logs it seems that I need to use either `fix` or `feature` so the commitlint trigger the release process.

## How was it tested?

--

----

cc @bigcommerce/storefront-team
