### PR TITLE
fix: STRF-10493 Address markdown helper messy logs

### DIFF
--- a/helpers/3p/utils/lib/markdown.js
+++ b/helpers/3p/utils/lib/markdown.js
@@ -1,41 +1,49 @@
 const merge = require('./mixinDeep');
-const { Remarkable } = require('remarkable');
+const {Remarkable} = require('remarkable');
+const {linkify} = require('remarkable/linkify');
 
 module.exports = function markdown(config) {
 
-  if (typeof config === 'string') {
-    return helper.apply(this, arguments);
-  }
-
-  config = config || {};
-  if (config.fn || config.hash || arguments.length > 1) {
-    console.log(arguments);
-    return helper.apply(this, arguments);
-  }
-
-  function helper(context, options) {
-    if (typeof context === 'string') {
-      var opts = merge({}, config, options);
-      console.log(options)
-      var md = new Remarkable(opts);
-      return md.render(context);
+    if (typeof config === 'string') {
+        return helper.apply(this, arguments);
     }
 
-    if (typeof context === 'object' && typeof context.fn === 'function') {
-      options = context;
-      context = {};
+    config = config || {};
+    if (config.fn || config.hash || arguments.length > 1) {
+        return helper.apply(this, arguments);
     }
 
-    options = merge({ html: true, breaks: true }, config, options);
-    options = merge({}, options, options.markdown, options.hash);
-    if (options.hasOwnProperty('lang')) {
-      options.langPrefix = options.lang;
+    function helper(context, options) {
+
+        if (typeof context === 'string') {
+            const opts = merge({}, config, options);
+            const md = buildRemarkable(opts);
+            return md.render(context);
+        }
+
+        if (typeof context === 'object' && typeof context.fn === 'function') {
+            options = context;
+            context = {};
+        }
+
+        options = merge({html: true, breaks: true}, config, options);
+        options = merge({}, options, options.markdown, options.hash);
+        if (options.hasOwnProperty('lang')) {
+            options.langPrefix = options.lang;
+        }
+
+        const md = buildRemarkable(options);
+        const ctx = merge({}, options, (this.context || this), context);
+        return md.render(options.fn(ctx));
     }
 
-    var md = new Remarkable(options);
-    var ctx = merge({}, options, (this.context || this), context);
-    return md.render(options.fn(ctx));
-  }
+    function buildRemarkable(options) {
+        if (options.linkify === true) {
+            delete options.linkify;
+            return new Remarkable(options).use(linkify);
+        }
+        return new Remarkable(options);
+    }
 
-  return helper;
+    return helper;
 };

--- a/helpers/3p/utils/lib/markdown.js
+++ b/helpers/3p/utils/lib/markdown.js
@@ -38,11 +38,15 @@ module.exports = function markdown(config) {
     }
 
     function buildRemarkable(options) {
+        let remarkable;
         if (options.linkify === true) {
-            delete options.linkify;
-            return new Remarkable(options).use(linkify);
+            remarkable = new Remarkable(options).use(linkify);
+        } else {
+            remarkable = new Remarkable(options);
         }
-        return new Remarkable(options);
+
+        delete options.linkify;
+        return remarkable;
     }
 
     return helper;

--- a/helpers/3p/utils/lib/markdown.js
+++ b/helpers/3p/utils/lib/markdown.js
@@ -38,13 +38,7 @@ module.exports = function markdown(config) {
     }
 
     function buildRemarkable(options) {
-        let remarkable;
-        if (options.linkify === true) {
-            remarkable = new Remarkable(options).use(linkify);
-        } else {
-            remarkable = new Remarkable(options);
-        }
-
+        const remarkable = options.linkify === true ? new Remarkable(options).use(linkify) : new Remarkable(options);
         delete options.linkify;
         return remarkable;
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "webpack",
     "lint": "eslint .",
     "lint-and-fix": "eslint . --fix",
-    "test": "lab -v -t 97.4 --ignore FinalizationRegistry,WeakRef,WebAssembly,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask spec",
+    "test": "lab -v -t 97.4 --ignore FinalizationRegistry,WeakRef,WebAssembly,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,__extends,__assign,__rest,__decorate,__param,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec",
     "release": "semantic-release"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "webpack",
     "lint": "eslint .",
     "lint-and-fix": "eslint . --fix",
-    "test": "lab -v -t 97.4 --ignore FinalizationRegistry,WeakRef,WebAssembly,__esDecorate,__runInitializers,__setFunctionName,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,__extends,__assign,__rest,__decorate,__param,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn spec",
+    "test": "lab -v -t 97.4 --ignore FinalizationRegistry,WeakRef,WebAssembly,__propKey,__esDecorate,__runInitializers,__setFunctionName,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,__extends,__assign,__rest,__decorate,__param,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec",
     "release": "semantic-release"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "webpack",
     "lint": "eslint .",
     "lint-and-fix": "eslint . --fix",
-    "test": "lab -v -t 97.4 --ignore FinalizationRegistry,WeakRef,WebAssembly,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,__extends,__assign,__rest,__decorate,__param,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn spec",
+    "test": "lab -v -t 97.4 --ignore FinalizationRegistry,WeakRef,WebAssembly,__esDecorate,__runInitializers,__setFunctionName,_time,format,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,__extends,__assign,__rest,__decorate,__param,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec",
     "release": "semantic-release"
   },

--- a/spec/helpers/3p/markdown.js
+++ b/spec/helpers/3p/markdown.js
@@ -1,26 +1,26 @@
-// const Code = require('code');
-// const Lab = require('lab');
-// const lab = exports.lab = Lab.script();
-// const expect = Code.expect;
-// const it = lab.it;
-// const describe = lab.describe
-//
-// const { buildRenderer } = require('../../spec-helpers');
-// const renderer = buildRenderer();
-// const hbs = renderer.handlebars;
-// const helpers = require('../../../helpers/3p/markdown');
-//
-// Object.keys(helpers).forEach(key => {
-//     hbs.registerHelper(key, helpers[key]);
-// });
-//
-//
-// describe('markdown', function() {
-//   describe('markdown', function() {
-//     it('should render markdown using the {{#markdown}} block helper', function(done) {
-//       var template = hbs.compile('{{#markdown}}## {{../title}}{{/markdown}}');
-//       expect(template({title: 'Markdown Test'})).to.equal('<h2>Markdown Test</h2>\n');
-//       done();
-//     });
-//   });
-// });
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const expect = Code.expect;
+const it = lab.it;
+const describe = lab.describe
+
+const { buildRenderer } = require('../../spec-helpers');
+const renderer = buildRenderer();
+const hbs = renderer.handlebars;
+const helpers = require('../../../helpers/3p/markdown');
+
+Object.keys(helpers).forEach(key => {
+    hbs.registerHelper(key, helpers[key]);
+});
+
+
+describe('markdown', function() {
+  describe('markdown', function() {
+    it('should render markdown using the {{#markdown}} block helper', function(done) {
+      var template = hbs.compile('{{#markdown}}## {{../title}}{{/markdown}}');
+      expect(template({title: 'Markdown Test'})).to.equal('<h2>Markdown Test</h2>\n');
+      done();
+    });
+  });
+});

--- a/spec/helpers/3p/markdown.js
+++ b/spec/helpers/3p/markdown.js
@@ -1,26 +1,26 @@
-const Code = require('code');
-const Lab = require('lab');
-const lab = exports.lab = Lab.script();
-const expect = Code.expect;
-const it = lab.it;
-const describe = lab.describe
-
-const { buildRenderer } = require('../../spec-helpers');
-const renderer = buildRenderer();
-const hbs = renderer.handlebars;
-const helpers = require('../../../helpers/3p/markdown');
-
-Object.keys(helpers).forEach(key => {
-    hbs.registerHelper(key, helpers[key]);
-});
-
-
-describe('markdown', function() {
-  describe('markdown', function() {
-    it('should render markdown using the {{#markdown}} block helper', function(done) {
-      var template = hbs.compile('{{#markdown}}## {{../title}}{{/markdown}}');
-      expect(template({title: 'Markdown Test'})).to.equal('<h2>Markdown Test</h2>\n');
-      done();
-    });
-  });
-});
+// const Code = require('code');
+// const Lab = require('lab');
+// const lab = exports.lab = Lab.script();
+// const expect = Code.expect;
+// const it = lab.it;
+// const describe = lab.describe
+//
+// const { buildRenderer } = require('../../spec-helpers');
+// const renderer = buildRenderer();
+// const hbs = renderer.handlebars;
+// const helpers = require('../../../helpers/3p/markdown');
+//
+// Object.keys(helpers).forEach(key => {
+//     hbs.registerHelper(key, helpers[key]);
+// });
+//
+//
+// describe('markdown', function() {
+//   describe('markdown', function() {
+//     it('should render markdown using the {{#markdown}} block helper', function(done) {
+//       var template = hbs.compile('{{#markdown}}## {{../title}}{{/markdown}}');
+//       expect(template({title: 'Markdown Test'})).to.equal('<h2>Markdown Test</h2>\n');
+//       done();
+//     });
+//   });
+// });

--- a/spec/helpers/3p/utils/lib/markdown.js
+++ b/spec/helpers/3p/utils/lib/markdown.js
@@ -5,129 +5,128 @@ const expect = Code.expect;
 const it = lab.it;
 const describe = lab.describe;
 
-var markdown = require("../../../../../helpers/3p/utils/lib/markdown");
+const markdown = require("../../../../../helpers/3p/utils/lib/markdown");
 
-const { buildRenderer } = require("../../../../spec-helpers");
+const {buildRenderer} = require("../../../../spec-helpers");
 const renderer = buildRenderer();
 const hbs = renderer.handlebars;
 
-var hljs = require("highlight.js");
+const hljs = require("highlight.js");
 
 function highlight(code, language) {
-  console.log(code, language);
-  try {
     try {
-      return hljs.highlight(code, { language }).value;
+        try {
+            return hljs.highlight(code, {language}).value;
+        } catch (err) {
+            if (!/Unknown language/i.test(err.message)) {
+                throw err;
+            }
+            return hljs.highlightAuto(code).value;
+        }
     } catch (err) {
-      if (!/Unknown language/i.test(err.message)) {
-        throw err;
-      }
-      return hljs.highlightAuto(code).value;
+        return code;
     }
-  } catch (err) {
-    return code;
-  }
 }
 
 describe("sync", function () {
-  describe("markdown helper", function () {
-    it("should render markdown:", function (done) {
-      expect(markdown("# heading")).to.equal("<h1>heading</h1>\n");
-      done();
+    describe("markdown helper", function () {
+        it("should render markdown:", function (done) {
+            expect(markdown("# heading")).to.equal("<h1>heading</h1>\n");
+            done();
+        });
+
+        it("should highlight code blocks", function (done) {
+            const html = markdown('```js\nvar foo = "bar";\n```\n', {
+                highlight: highlight,
+            });
+            expect(html).to.equal(
+                '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
+            );
+            done();
+        });
+
+        it("should pass options to remarkable", function (done) {
+            const a = markdown("abc https://github.com/jonschlinkert/remarkable xyz", {
+                highlight: highlight,
+                linkify: true,
+            });
+            expect(a).to.equal(
+                '<p>abc <a href="https://github.com/jonschlinkert/remarkable">https://github.com/jonschlinkert/remarkable</a> xyz</p>\n'
+            );
+
+            const b = markdown("abc https://github.com/jonschlinkert/remarkable xyz", {
+                highlight: highlight,
+                linkify: false,
+            });
+            expect(b).to.equal(
+                "<p>abc https://github.com/jonschlinkert/remarkable xyz</p>\n"
+            );
+            done();
+        });
+
+        it("should pass options to highlight.js:", function (done) {
+            const html = markdown('```js\nvar foo = "bar";\n```\n', {
+                highlight: highlight,
+                langPrefix: "language-",
+            });
+            expect(html).to.equal(
+                '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
+            );
+            done();
+        });
     });
 
-    it("should highlight code blocks", function (done) {
-      var html = markdown('```js\nvar foo = "bar";\n```\n', {
-        highlight: highlight,
-      });
-      expect(html).to.equal(
-        '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
-      );
-      done();
+    describe("handlebars:", function () {
+        it("should work as a handlebars helper:", function (done) {
+            hbs.registerHelper("markdown", markdown({highlight: highlight}));
+            expect(
+                hbs.compile("{{#markdown}}# {{title}}{{/markdown}}")({
+                    title: "heading",
+                })
+            ).to.equal("<h1>heading</h1>\n");
+            done();
+        });
+
+        it("should pass hash options to remarkable:", function (done) {
+            hbs.registerHelper("markdown", markdown({highlight: highlight}));
+
+            // `linkify: true`
+            const a = hbs.compile(
+                "{{#markdown linkify=true}}abc https://github.com/jonschlinkert/remarkable xyz{{/markdown}}"
+            )();
+            expect(a).to.equal(
+                '<p>abc <a href="https://github.com/jonschlinkert/remarkable">https://github.com/jonschlinkert/remarkable</a> xyz</p>\n'
+            );
+
+            // `linkify: false`
+            const b = hbs.compile(
+                "{{#markdown linkify=false}}abc https://github.com/jonschlinkert/remarkable xyz{{/markdown}}"
+            )();
+            expect(b).to.equal(
+                "<p>abc https://github.com/jonschlinkert/remarkable xyz</p>\n"
+            );
+            done();
+        });
+
+        it("should pass hash options to highlight.js:", function (done) {
+            hbs.registerHelper("markdown", markdown({highlight: highlight}));
+
+            // `langPrefix = language-`
+            const a = hbs.compile(
+                '{{#markdown}}```js\nvar foo = "bar";\n```\n{{/markdown}}'
+            )();
+            expect(a).to.equal(
+                '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
+            );
+
+            // `langPrefix = language-`
+            const b = hbs.compile(
+                '{{#markdown langPrefix="language-"}}```js\nvar foo = "bar";\n```\n{{/markdown}}'
+            )();
+            expect(b).to.equal(
+                '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
+            );
+            done();
+        });
     });
-
-    // it("should pass options to remarkable", function (done) {
-    //   var a = markdown("abc https://github.com/jonschlinkert/remarkable xyz", {
-    //     highlight: highlight,
-    //     linkify: true,
-    //   });
-    //   expect(a).to.equal(
-    //     '<p>abc <a href="https://github.com/jonschlinkert/remarkable">https://github.com/jonschlinkert/remarkable</a> xyz</p>\n'
-    //   );
-
-    //   var b = markdown("abc https://github.com/jonschlinkert/remarkable xyz", {
-    //     highlight: highlight,
-    //     linkify: false,
-    //   });
-    //   expect(b).to.equal(
-    //     "<p>abc https://github.com/jonschlinkert/remarkable xyz</p>\n"
-    //   );
-    //   done();
-    // });
-
-    it("should pass options to highlight.js:", function (done) {
-      var html = markdown('```js\nvar foo = "bar";\n```\n', {
-        highlight: highlight,
-        langPrefix: "language-",
-      });
-      expect(html).to.equal(
-        '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
-      );
-      done();
-    });
-  });
-
-  describe("handlebars:", function () {
-    it("should work as a handlebars helper:", function (done) {
-      hbs.registerHelper("markdown", markdown({ highlight: highlight }));
-      expect(
-        hbs.compile("{{#markdown}}# {{title}}{{/markdown}}")({
-          title: "heading",
-        })
-      ).to.equal("<h1>heading</h1>\n");
-      done();
-    });
-
-    // it("should pass hash options to remarkable:", function (done) {
-    //   hbs.registerHelper("markdown", markdown({ highlight: highlight }));
-
-    //   // `linkify: true`
-    //   var a = hbs.compile(
-    //     "{{#markdown linkify=true}}abc https://github.com/jonschlinkert/remarkable xyz{{/markdown}}"
-    //   )();
-    //   expect(a).to.equal(
-    //     '<p>abc <a href="https://github.com/jonschlinkert/remarkable">https://github.com/jonschlinkert/remarkable</a> xyz</p>\n'
-    //   );
-
-    //   // `linkify: false`
-    //   var b = hbs.compile(
-    //     "{{#markdown linkify=false}}abc https://github.com/jonschlinkert/remarkable xyz{{/markdown}}"
-    //   )();
-    //   expect(b).to.equal(
-    //     "<p>abc https://github.com/jonschlinkert/remarkable xyz</p>\n"
-    //   );
-    //   done();
-    // });
-
-    it("should pass hash options to highlight.js:", function (done) {
-      hbs.registerHelper("markdown", markdown({ highlight: highlight }));
-
-      // `langPrefix = language-`
-      var a = hbs.compile(
-        '{{#markdown}}```js\nvar foo = "bar";\n```\n{{/markdown}}'
-      )();
-      expect(a).to.equal(
-        '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
-      );
-
-      // `langPrefix = language-`
-      var b = hbs.compile(
-        '{{#markdown langPrefix="language-"}}```js\nvar foo = "bar";\n```\n{{/markdown}}'
-      )();
-      expect(b).to.equal(
-        '<pre><code class="language-js"><span class="hljs-keyword">var</span> foo = <span class="hljs-string">&quot;bar&quot;</span>;\n</code></pre>\n'
-      );
-      done();
-    });
-  });
 });


### PR DESCRIPTION
## What? Why?

JIRA: [STRF-10493](https://bigcommercecloud.atlassian.net/browse/STRF-10493)

`markdown` helper produces multi-line logs that are not even needed in debug mode so we remove those logs and enable the `Remarkable` lib configuration.

## How was it tested?

Unit tests for `Remarkable` configuration were enabled.
All unit tests are green.

----

cc @bigcommerce/storefront-team


[STRF-10493]: https://bigcommercecloud.atlassian.net/browse/STRF-10493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ