### PR TITLE
fix: fixes cdn helper early hint construction

### DIFF
--- a/helpers/cdn.js
+++ b/helpers/cdn.js
@@ -11,7 +11,8 @@ const factory = globals => {
             globals,
             fullPath,
             options.hash.resourceHint,
-            options.hash.as
+            options.hash.as,
+            options.hash.crossorigin
         );
     }
 

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -29,23 +29,25 @@ describe('cdn helper', function () {
         const runTestCases = testRunner({context, renderer});
         runTestCases([
             {
-                input: '{{cdn "assets/css/style.css" resourceHint="preload" as="style"}}',
+                input: '{{cdn "assets/css/style.css" resourceHint="preload" as="style" crossorigin="use-credentials"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.css',
             },
             {
-                input: '{{cdn "/assets/css/style.modal.css" resourceHint="preconnect" as="style"}}',
+                input: '{{cdn "/assets/css/style.modal.css" resourceHint="preconnect" as="style" crossorigin="anonymous"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.modal.css',
             },
             {
-                input: '{{cdn "/assets/css/style.modal.css" as="style"}}',
+                input: '{{cdn "/assets/css/style.modal.css" as="style" crossorigin="use-credentials"}}',
                 output: 'https://cdn.bcapp/3dsf74g/stencil/123/css/style.modal.css',
             }
         ], () => {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(2);
             hints.forEach(hint => {
+                console.warn(hint);
                 expect(hint.state).to.satisfy((state) => state === 'preload' || state === 'preconnect');
-                expect(hint.type).to.equals("style")
+                expect(hint.type).to.equals("style");
+                expect(hint.cors).to.satisfy((cors) => cors === 'anonymous' || cors === 'use-credentials');
             });
             done();
         });
@@ -65,6 +67,7 @@ describe('cdn helper', function () {
             hints.forEach(hint => {
                 expect(hint.state).to.equals('preload');
                 expect(hint.type).to.not.exist();
+                expect(hint.cors).to.equals('no');
             });
             done();
         });

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -44,7 +44,6 @@ describe('cdn helper', function () {
             const hints = renderer.getResourceHints();
             expect(hints).to.have.length(2);
             hints.forEach(hint => {
-                console.warn(hint);
                 expect(hint.state).to.satisfy((state) => state === 'preload' || state === 'preconnect');
                 expect(hint.type).to.equals("style");
                 expect(hint.cors).to.satisfy((cors) => cors === 'anonymous' || cors === 'use-credentials');


### PR DESCRIPTION
## What? Why?

A customer reported that `cdn` helper was no able to construct a proper early hint (specifically the usage of `crossorigin` attribute).

## How was it tested?

- unit tests

----

cc @bigcommerce/storefront-team
