### PR TITLE
fix: STRF-10878 Fix money symbol position when setting is capitalized

### DIFF
--- a/helpers/money.js
+++ b/helpers/money.js
@@ -44,7 +44,7 @@ const factory = globals => {
             decimalToken
         );
 
-        return money.currency_location === 'left'
+        return money.currency_location.toLowerCase() === 'left'
             ? money.currency_token + ' ' + value
             : value + ' ' + money.currency_token;
     };

--- a/spec/helpers/money.js
+++ b/spec/helpers/money.js
@@ -56,6 +56,26 @@ describe('money helper', function() {
         ], done);
     });
 
+    it('should correctly set currency position regardless of location capitalization - [STRF-10878]', function(done) {
+        const settingsWithCapitalizedLocation = {
+            money: {
+                currency_location: "Left",
+                currency_token: "$",
+                decimal_places: 2,
+                thousands_token: ',',
+                decimal_token: '.',
+            }
+        };
+
+        const runTestCases = testRunner({ context, siteSettings: settingsWithCapitalizedLocation });
+        runTestCases([
+            {
+                input: '{{money price}}',
+                output: '$ 1,234.56',
+            },
+        ], done);
+    });
+
     it('should throw an exception if the price value parameter has an invalid type', function(done) {
         renderString('{{money "hello"}}').catch(err => {
             expect(err.message).to.equal("money helper accepts only Number's as first parameter");


### PR DESCRIPTION
### Jira: https://bigcommercecloud.atlassian.net/browse/STRF-10878

## What?
Currently, the `money` helper will not properly position the currency symbol if the setting received has a capital letter. I found that on some stores, the currency location can sometimes default with the first letter capitalized (e.g. `Left` instead of `left`)

## Why?
The currency location should not be case sensitive.

## How was it tested?
- Unit tests

----

cc @bigcommerce/storefront-team
