### PR TITLE
feat(merc): MERC-9364 Use CDN Original images for webdav - cache control

### DIFF
--- a/helpers/lib/cdnify.js
+++ b/helpers/lib/cdnify.js
@@ -56,7 +56,7 @@ module.exports = globals => {
             }
 
             if (protocol === 'webdav:') {
-                return [cdnUrl, 'content', path].join('/');
+                return [cdnUrl, 'images/stencil/original', 'content', path].join('/');
             }
 
             if (cdnSettings) {

--- a/spec/helpers/cdn.js
+++ b/spec/helpers/cdn.js
@@ -198,15 +198,15 @@ describe('cdn helper', function () {
         runTestCases([
             {
                 input: '{{cdn "webdav:img/image.jpg"}}',
-                output: 'https://cdn.bcapp/3dsf74g/content/img/image.jpg',
+                output: 'https://cdn.bcapp/3dsf74g/images/stencil/original/content/img/image.jpg',
             },
             {
                 input: '{{cdn "webdav:/img/image.jpg"}}',
-                output: 'https://cdn.bcapp/3dsf74g/content/img/image.jpg',
+                output: 'https://cdn.bcapp/3dsf74g/images/stencil/original/content/img/image.jpg',
             },
             {
                 input: '{{cdn "webdav://img/image.jpg"}}',
-                output: 'https://cdn.bcapp/3dsf74g/content/img/image.jpg',
+                output: 'https://cdn.bcapp/3dsf74g/images/stencil/original/content/img/image.jpg',
             },
         ], done);
     });


### PR DESCRIPTION
- [ ] [Paper Handlebars](https://github.com/bigcommerce/paper-handlebars/pull/273)
- [ ] [Paper](https://github.com/bigcommerce/paper/pull/343) (bump version)
- [ ] Stencil Cli (bump version)
- [ ] Storefront Renderer (bump verion) 

## What? Why?
Use CDN Original images for webdav - cache control. 

If a developer/merchant decide to use the handlebar to import images from WebDav into the theme `({{cdn "webdav:/img/image.jpg"}})`, there is no cache-control header when the image is presented to the storefront.

Similar to our Image Manager, we should be using the cdn original images (Similar to Jinsoo's PR here [MERC-7127](https://github.com/bigcommerce/bigcommerce/pull/47254)


Example images:
[Original /content/](https://cdn11.bigcommerce.com/s-hc1qesrzsh/content/webdev-pat.jpg)

[Updated /images/stencil/original/content/](https://cdn11.bigcommerce.com/s-hc1qesrzsh/images/stencil/original/content/webdev-pat.jpg)

## How was it tested?
Tested locally

cc @bigcommerce/storefront-team


[MERC-7127]: https://bigcommercecloud.atlassian.net/browse/MERC-7127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ