### PR TITLE
fix: bump release step github actions and semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
       - run: npm i

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "husky": "^8.0.1",
     "lab": "~13.0.4",
     "path-browserify": "^1.0.1",
-    "semantic-release": "^19.0.5",
+    "semantic-release": "^21.0.7",
     "semantic-release-github-pullrequest": "^1.3.0",
     "sinon": "~7.5.0",
     "url": "^0.11.0",


### PR DESCRIPTION
## What? Why?
- Bump Release GA versions
- Bump semantic release

## How was it tested?

----

cc @bigcommerce/storefront-team
