### PR TITLE
fix: STRF-9936 Replaced outdated date.js with chrono

### DIFF
--- a/helpers/moment.js
+++ b/helpers/moment.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const utils = require('./3p/utils');
-const date = require('date.js');
+const chrono = require('chrono-node');
 
 // suppress error messages that are not actionable
 const moment = require('moment');
@@ -40,7 +40,7 @@ const factory = () => {
         // so instead of doing magic we'll just ask the user to tell
         // us if the args should be passed to date.js or moment.
         if (typeof str === 'string' && typeof pattern === 'string') {
-            return moment(date(str)).format(pattern);
+            return moment(chrono.parseDate(str)).format(pattern);
         }
 
         // If handlebars, expose moment methods as hash properties

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/bigcommerce/paper-handlebars",
   "dependencies": {
     "@bigcommerce/handlebars-v4": "4.7.6",
-    "date.js": "^0.3.3",
+    "chrono-node": "^2.6.5",
     "handlebars": "3.0.8",
     "he": "^1.2.0",
     "moment": "^2.29.4",

--- a/spec/helpers/moment.js
+++ b/spec/helpers/moment.js
@@ -14,6 +14,26 @@ describe('moment helper', function () {
             {
                 input: `{{moment "1 year ago" "YYYY"}}`,
                 output: `${now.getFullYear() - 1}`,
+            },
+            {
+                input: `{{moment "2 days ago" "YYYY"}}`,
+                output: `${now.getFullYear()}`,
+            },
+            {
+                input: `{{moment '2022-06-29' 'DD/MM/YYYY'}}`,
+                output: '29/06/2022',
+            },
+            {
+                input: `{{moment '2022-06-30' 'DD/MM/YYYY'}}`,
+                output: '30/06/2022',
+            },
+            {
+                input: `{{moment '2022-07-29' 'DD/MM/YYYY'}}`,
+                output: '29/07/2022',
+            },
+            {
+                input: `{{moment '2022-07-30' 'DD/MM/YYYY'}}`,
+                output: '30/07/2022',
             }
         ], done);
     });


### PR DESCRIPTION
## What? Why?
date.js have several bugs, is not supported and outdated.
chrono provides same capabilities


## How was it tested?
npm test

----

cc @bigcommerce/storefront-team
