### PR TITLE
fix: STRF-11164 bump handlebars v4 to 4.7.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper-handlebars",
   "dependencies": {
-    "@bigcommerce/handlebars-v4": "4.7.6",
+    "@bigcommerce/handlebars-v4": "4.7.8",
     "chrono-node": "^2.6.5",
     "handlebars": "3.0.8",
     "he": "^1.2.0",


### PR DESCRIPTION
## What? Why?

bump handlebars to 4.7.8

## How was it tested?

cdvm

----

cc @bigcommerce/storefront-team
