### PR TITLE
fix: strf-11673 Wrap nonce into SafeString

### DIFF
--- a/helpers/nonce.js
+++ b/helpers/nonce.js
@@ -4,7 +4,7 @@ const factory = globals => {
     return function() {
         const params = globals.getRequestParams();
         if (params && params.security && params.security.nonce) {
-            return ` nonce="${params.security.nonce}"`;
+            return new globals.handlebars.SafeString(` nonce="${params.security.nonce}"`);
         }
         return ''
     };

--- a/spec/helpers/nonce.js
+++ b/spec/helpers/nonce.js
@@ -17,7 +17,7 @@ describe('nonce helper', function () {
         runTestCases([
             {
                 input: '{{nonce}}',
-                output: ' nonce=&quot;' + requestParams.security.nonce + '&quot;',
+                output: ' nonce="' + requestParams.security.nonce + '"',
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?

Wrap nonce output into SafeString, so it doesn't get double quote on the browser
 

## How was it tested?
Before
<img width="324" alt="Screenshot 2024-03-14 at 18 23 48" src="https://github.com/bigcommerce/paper-handlebars/assets/68893868/5a2ef635-3b12-463d-a315-061df524762f">

After
<img width="393" alt="Screenshot 2024-03-14 at 18 21 55" src="https://github.com/bigcommerce/paper-handlebars/assets/68893868/a58ba447-480a-4708-9f70-4c06938494fe">


----

cc @bigcommerce/storefront-team
