### PR TITLE
chore(storefront): STRF-11941 Helper should just return nonce in quotes

### DIFF
--- a/helpers/nonce.js
+++ b/helpers/nonce.js
@@ -4,7 +4,7 @@ const factory = globals => {
     return function() {
         const params = globals.getRequestParams();
         if (params && params.security && params.security.nonce) {
-            return new globals.handlebars.SafeString(` nonce="${params.security.nonce}"`);
+            return new globals.handlebars.SafeString(`"${params.security.nonce}"`);
         }
         return ''
     };

--- a/spec/helpers/nonce.js
+++ b/spec/helpers/nonce.js
@@ -6,7 +6,7 @@ const {testRunner, buildRenderer, randomString} = require('../spec-helpers');
 describe('nonce helper', function () {
     const context = {}
 
-    it('should render a nonce html attribute with the correct value from request params', function (done) {
+    it('should render a nonce in quotes with the correct value from request params', function (done) {
         const requestParams = {
             security: {
                 nonce: randomString()
@@ -17,7 +17,7 @@ describe('nonce helper', function () {
         runTestCases([
             {
                 input: '{{nonce}}',
-                output: ' nonce="' + requestParams.security.nonce + '"',
+                output: '"' + requestParams.security.nonce + '"',
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?
https://bigcommercecloud.atlassian.net/browse/STRF-11941

Just return nonce in double quotes 

## How was it tested?
Dev VM

Before:
![Screenshot 2024-05-29 at 1 55 14 PM](https://github.com/bigcommerce/paper-handlebars/assets/5630999/7a40f81e-7056-410c-b1e6-513c128b05c0)

After:
![Screenshot 2024-05-29 at 1 54 10 PM](https://github.com/bigcommerce/paper-handlebars/assets/5630999/c302e968-6ba5-436a-842d-e049c4ee056e)


----

cc @bigcommerce/storefront-team
