### PR TITLE
fix(storefront): STRF-11941 Remove quotes from nonce

### DIFF
--- a/helpers/nonce.js
+++ b/helpers/nonce.js
@@ -4,7 +4,7 @@ const factory = globals => {
     return function() {
         const params = globals.getRequestParams();
         if (params && params.security && params.security.nonce) {
-            return new globals.handlebars.SafeString(`"${params.security.nonce}"`);
+            return new globals.handlebars.SafeString(params.security.nonce);
         }
         return ''
     };

--- a/spec/helpers/nonce.js
+++ b/spec/helpers/nonce.js
@@ -17,7 +17,7 @@ describe('nonce helper', function () {
         runTestCases([
             {
                 input: '{{nonce}}',
-                output: '"' + requestParams.security.nonce + '"',
+                output: requestParams.security.nonce,
             },
         ], done);
     });


### PR DESCRIPTION
## What? Why?

Remove the quotes from nonce helper. 

Collaboration with Merchandising on nonce.

## How was it tested?
Run storefront-renderer-2 locally with local paper and paper handlebars via npm link

1. cd into local paper and paper handlebars directories `npm link`
2. Then in storefront-renderer-2 
 `npm link @bigcommerce/stencil-paper `
`npm link @bigcommerce/stencil-paper-handlebars`
3. dev.yml
```
storefront-renderer-2:
    rpc:
      port: 9998
```

![Screenshot 2024-06-05 at 7 46 24 PM](https://github.com/bigcommerce/paper-handlebars/assets/5630999/ed4100aa-1aa5-4eeb-a2dc-b476ba79042a)



----

cc @bigcommerce/storefront-team cc @jkanive @bc-erich 
