### PR TITLE
fix(storefront): STRF-12281 Prevent block and partial helpers from being named prototype methods

### DIFF
--- a/helpers/block.js
+++ b/helpers/block.js
@@ -10,6 +10,12 @@ const factory = globals => {
             globals.getLogger().info("Non-string passed to block helper");
             return '';
         }
+
+        if (Object.getOwnPropertyNames(Object.prototype).includes(name)) {
+            globals.getLogger().info(`Invalid name '${name}' passed to the partial helper. Returning empty string.`);
+            return '';
+        }
+
         const options = arguments[arguments.length - 1];
 
         /* Look for partial by name. */

--- a/helpers/partial.js
+++ b/helpers/partial.js
@@ -10,6 +10,12 @@ const factory = globals => {
             globals.getLogger().info("Non-string passed to partial helper");
             return '';
         }
+
+        if (Object.getOwnPropertyNames(Object.prototype).includes(name)) {
+            globals.getLogger().info(`Invalid name '${name}' passed to the partial helper. Returning empty string.`);
+            return '';
+        }
+
         const options = arguments[arguments.length - 1];
         globals.handlebars.registerPartial(name, options.fn);
     };

--- a/spec/helpers/block.js
+++ b/spec/helpers/block.js
@@ -74,4 +74,18 @@ describe('partial and block helpers', function () {
             done();
         });
     });
+
+    it('should return empty string if using a reserved object property name', function (done) {
+        const templates = {
+            template: '{{#partial "__proto__"}}Page partial content.{{/partial}}{{> layout}}',
+            layout: '{{#block "constructor"}}{{/block}}',
+        };
+
+        const context = {};
+
+        render('template', context, {}, {}, templates).then(result => {
+            expect(result).to.equal('');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
### Jira: [STRF-12281](https://bigcommercecloud.atlassian.net/browse/STRF-12281)

## What/Why?
Prevent `partial` and `block` helpers from allowing names that are the same as native javascript object prototype methods.

## Rollout/Rollback
Roll back this PR

## Testing
Unit tests, ensured that error is not thrown and object prototype is not accessed.

----

cc @bigcommerce/team-storefront 


[STRF-12281]: https://bigcommercecloud.atlassian.net/browse/STRF-12281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ