### PR TITLE
fix: STRF-12276 Remove compile method from hbs renderer

### DIFF
--- a/helpers/3p/array.js
+++ b/helpers/3p/array.js
@@ -42,7 +42,9 @@ helpers.after = function(array, n) {
  * @api public
  */
 
-helpers.arrayify = function(value) {
+helpers.arrayify = function(...args) {
+  args.pop(); // remove handlebars options object
+  const value = args[0];
   return value ? (Array.isArray(value) ? value : [value]) : [];
 };
 

--- a/helpers/3p/inflection.js
+++ b/helpers/3p/inflection.js
@@ -18,7 +18,9 @@ var helpers = module.exports;
  * @api public
  */
 
-helpers.inflect = function(count, singular, plural, include) {
+helpers.inflect = function(...args) {
+  args.pop();
+  const [count, singular, plural, include] = args;
   var word = (count > 1 || count === 0) ? plural : singular;
 
   if (utils.isUndefined(include) || include === false) {

--- a/helpers/3p/misc.js
+++ b/helpers/3p/misc.js
@@ -16,7 +16,10 @@ var helpers = module.exports;
  * @api public
  */
 
-helpers.default = function(value, defaultValue) {
+helpers.default = function(...args) {
+  args.pop();
+  const value = args.shift();
+  const defaultValue = args.shift();
   return !value
     ? defaultValue
     : value;

--- a/helpers/deprecated/pick.js
+++ b/helpers/deprecated/pick.js
@@ -6,6 +6,7 @@ const factory = () => {
      * @deprecate
      */
     return function(...args) {
+        args.pop();
         const target = args.shift();
         const toReturn = {};
         const paths = args[0];

--- a/helpers/getImageSrcset.js
+++ b/helpers/getImageSrcset.js
@@ -3,7 +3,9 @@ const utils = require('./3p/utils');
 const common = require('./lib/common');
 
 const factory = globals => {
-    return function (image, defaultImageUrl) {
+    return function (...args) {
+        args.pop();
+        let [image, defaultImageUrl] = args;
         // Regex to test size string is of the form 123x123 or 100w
         const sizeRegex = /(^\d+w$)|(^(\d+?)x(\d+?)$)/;
         // Regex to test to that srcset descriptor is of the form 1x 1.5x 2x OR 123w

--- a/helpers/getObject.js
+++ b/helpers/getObject.js
@@ -10,7 +10,9 @@ const { getValue } = require('./lib/common');
  * Property paths (`a.b.c`) may be used to get nested properties.
  */
 const factory = (globals) => {
-    return function (path, context) {
+    return function (...args) {
+        args.pop();
+        let [path, context] = args;
         // use an empty context if none was given
         // (expect 3 args: `path`, `context`, and the `options` object 
         // Handlebars always passes as the last argument to a helper)

--- a/helpers/toLowerCase.js
+++ b/helpers/toLowerCase.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const factory = () => {
-    return function(string) {
+    return function(...args) {
+        args.pop();
+        const string = args[0];
         if (typeof string !== 'string') {
             return string;
         }

--- a/helpers/truncate.js
+++ b/helpers/truncate.js
@@ -24,7 +24,9 @@ const substring = require('stringz').substring;
  *  {{lang (truncate 'blog.post.body.' 40) }}
  */
 const factory = globals => {
-    return function(string, length) {
+    return function(...args) {
+        args.pop();
+        const [string, length] = args;
         if (typeof string !== 'string' || string.length === 0) {
             return string;
         }

--- a/index.js
+++ b/index.js
@@ -296,6 +296,8 @@ class HandlebarsRenderer {
                 context.locale_name = this._translator.getLocale();
             }
 
+            delete this.handlebars.compile;
+
             // Look up the template
             const template = this.handlebars.partials[path];
             if (typeof template === 'undefined') {
@@ -333,11 +335,19 @@ class HandlebarsRenderer {
      */
     renderString(template, context) {
         return new Promise((resolve, reject) => {
+            let precompiledTemplate;
             context = context || {};
+
+            if (typeof template !== 'string') {
+                return reject(new CompileError('Template must be a string'));
+            }
 
             // Compile the template
             try {
-                template = this.handlebars.compile(template);
+                delete this.handlebars.compile;
+                const precompiled = this.handlebars.precompile(template, handlebarsOptions);
+                eval(`precompiledTemplate = ${precompiled}`);
+                template = this.handlebars.template(precompiledTemplate);
             } catch(e) {
                 return reject(new CompileError(e.message));
             }


### PR DESCRIPTION
## What? Why?

Remove compile method from handlebars renderer runtime to prefer the precompiled option for render and renderString

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
