### PR TITLE
feat: add precompile error for renderString

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,6 +6,7 @@ class RenderError extends AppError {};           // Error rendering template
 class DecoratorError extends AppError {};        // Error applying decorator
 class TemplateNotFoundError extends AppError {}; // Template not registered
 class ValidationError extends Error {};
+class PrecompileError extends Error {};
 
 module.exports = {
     CompileError,
@@ -13,5 +14,6 @@ module.exports = {
     RenderError,
     DecoratorError,
     TemplateNotFoundError,
-    ValidationError 
+    ValidationError,
+    PrecompileError
 };

--- a/spec/index.js
+++ b/spec/index.js
@@ -372,9 +372,9 @@ describe('renderString', () => {
         });
     });
 
-    it('throws RenderError if given malformed template', done => {
+    it('throws PrecompileError if given malformed template', done => {
         renderer.renderString('{{', context).catch(e => {
-            expect(e instanceof HandlebarsRenderer.errors.CompileError).to.be.true();
+            expect(e instanceof HandlebarsRenderer.errors.PrecompileError).to.be.true();
             done();
         });
     });


### PR DESCRIPTION
## What? Why?

Add Precompile Error for renderString.

EmailRenderer had validation logic that was relying on another error type that is not thrown anymore, so had to add a new type 

## How was it tested?

npm test / email-renderer

----

cc @bigcommerce/storefront-team
