### PR TITLE
fix: STRF-12532 Set Access has been denied to resolve the property message to info level

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,6 +385,8 @@ class HandlebarsRenderer {
                 let method = this.handlebars.logger.methodMap[level];
                 if (typeof this.logger[method] !== 'function') {
                     method = 'log';
+                } else if (this._overrideHandlebarsAccessDeniedToPropertyMessageLevel(...message)) {
+                    method = 'info';
                 }
                 this.logger[method](...message);
             }
@@ -395,12 +397,18 @@ class HandlebarsRenderer {
      * As some handlebars helpers do not use the logger, we need to override the console.log method 
      */
     _overrideConsoleLog() {
+        this.isLoggerOverriden = false;
         if (this.logger !== console) {
             console.log = this.logger.info.bind(this.logger);
             console.info = this.logger.info.bind(this.logger);
             console.error = this.logger.error.bind(this.logger);
             console.warn = this.logger.warn.bind(this.logger);
+            this.isLoggerOverriden = true;
         }
+    }
+
+    _overrideHandlebarsAccessDeniedToPropertyMessageLevel(message) {
+        return this.isLoggerOverriden && message.includes('Handlebars: Access has been denied to resolve the property');
     }
 
     /**

--- a/spec/index.js
+++ b/spec/index.js
@@ -513,6 +513,22 @@ describe('logging', () => {
         done();
     });
 
+    it('should check that property access denied message is set as info', async () => {
+        const renderer = new HandlebarsRenderer({}, {}, 'v4', logger);
+        const result = await renderer.renderString("{{aString.trim}}", { aString: "  abc  " });
+        expect(result).to.equal("");
+        expect(logger.info.calledWith('Handlebars: Access has been denied to resolve the property "trim" because it is not an "own property" of its parent.\n' + 'You can add a runtime option to disable the check or this warning:\n' + 'See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details'))
+            .to.equal(true);
+    });
+
+    it('should check that property access denied message is set as error', async () => {
+        console.error = Sinon.fake();
+        const renderer = new HandlebarsRenderer({}, {}, 'v4', console);
+        const result = await renderer.renderString("{{aString.toLowerCase}}", { aString: "  abc  " });
+        expect(result).to.equal("");
+        expect(console.error.calledWith('Handlebars: Access has been denied to resolve the property "toLowerCase" because it is not an "own property" of its parent.\n' + 'You can add a runtime option to disable the check or this warning:\n' + 'See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details'))
+            .to.equal(true);
+    });
 });
 
 // STRF-12276


### PR DESCRIPTION
## What? Why?
Set "Handlebars: Access has been denied to resolve the property" message to info level

## How was it tested?

`npm test`

----

cc @bigcommerce/storefront-team
