### PR TITLE
Update region.js - Proposal for flags `empty` and `raw`

### DIFF
--- a/helpers/region.js
+++ b/helpers/region.js
@@ -4,15 +4,29 @@ const factory = globals => {
     return function(params) {
         let regionId = params.hash.name;
         let regionTranslation = params.hash.translation;
+        let regionEmpty = params.hash.empty; //Propal key of empty
+        let regionRaw = params.hash.raw; //Propal key of raw
         let contentRegions = globals.getContent();
 
         if (!contentRegions) {
             return '';
         }
-        const translationDataAttribute = regionTranslation ? ` data-content-region-translation="${regionTranslation}"` : '';
 
-        const content = `<div data-content-region="${regionId}"${translationDataAttribute}>${contentRegions[regionId] || ''}</div>`;
+        // If content is empty, and flag to render nothing `empty` is set, then return nothing because there is nothing to render.
+        if (!contentRegions[regionId] && regionEmpty) {
+            return '';
+        }
 
+        //Write just the region content to the output variable.
+        //If the flag is set for raw rendering, this will be the output.
+        let content = contentRegions[regionId] || '';
+        if (!regionRaw) {
+            //Return the original structure that is typical of the {{region}} handlebars entity.
+            const translationDataAttribute = regionTranslation ? ` data-content-region-translation="${regionTranslation}"` : '';
+            //Original returned structure.
+            content = `<div data-content-region="${regionId}"${translationDataAttribute}>${contentRegions[regionId] || ''}</div>`;
+        }
+        
         return new globals.handlebars.SafeString(content);
     };
 };


### PR DESCRIPTION
Added proposal parameters for a variance in the return state of the region block helper.

`empty`: When the `empty` flag is truthy, if there is no content currently available for the named region; then return a empty string instead of the normal div wrapper.

`raw`: When the `raw` flag is truthy, omit the normal div wrapper when returning the region content.

## What? Why?
Because empty region blocks add extra HTML into rendered content resulting in the CSS for selectors needing to pass through a additional div before they can trigger. Example of :empty selector.
https://developer.mozilla.org/en-US/docs/Web/CSS/:empty

## How was it tested?
Not tested due to no testing protocol found in repo. 

----

cc @bigcommerce/storefront-team
