### PR TITLE
Update math.js to include min, max, and clamp functions

### DIFF
--- a/helpers/3p/math.js
+++ b/helpers/3p/math.js
@@ -135,3 +135,60 @@ helpers.avg = function() {
   args.pop();
   return exports.sum(args) / args.length;
 };
+
+/**
+ * Return the min of `a` and `b`.
+ * ```handlebars
+ * {{min 1 5}}
+ * //=> '1'
+ * ```
+ *
+ * @param {Number} `a`
+ * @param {Number} `b`
+ * @api public
+ */
+
+helpers.min = function(a, b) {
+  return a < b ? a : b;
+}
+
+
+/**
+ * Return the max of `a` and `b`.
+ * ```handlebars
+ * {{max 1 5}}
+ * //=> '5'
+ * ```
+ *
+ * @param {Number} `a`
+ * @param {Number} `b`
+ * @api public
+ */
+
+helpers.max = function(a, b) {
+  return a > b ? a : b;
+}
+
+
+/**
+ * Return the value `test` constrained to the provided `min` and `max`.
+ * If the value `test` falls outside of the provided `min` or `max`, the respective bounds will be returned instead.
+ *
+ * ```handlebars
+ * {{clamp 3 2 4}}
+ * //=> '3'
+ * {{clamp 10 2 4}}
+ * //=> '4'
+ * {{clamp -10 2 4}}
+ * //=> '2'
+ * ```
+ *
+ * @param {Number} `test`
+ * @param {Number} `min`
+ * @param {Number} `max`
+ * @api public
+ */
+
+helpers.clamp = function(test, min, max) {
+  return helpers.max(min, helpers.min(text, max));
+}


### PR DESCRIPTION
Include of simple math helpers for inline calculations. All support Number types of Int and Float, but not edge case numbers such as NaN, +-infinity, or undefined.

Min: given `A` and `B` return the smaller of the two on a standard number line.

Max: given `A` and `B` return the larger of the two on a standard number line.

Clamp: given `test`, `min` and `max` return the tested value if it falls within the range of `min` and `max` such that `min < test < max` is satisfied on a standard number line.  If the constraint is not satisfied, return the closest bounding constraint.

## What? Why?
Because these math functions are currently missing from the standard library.

## How was it tested?
None required, mirror of existing function `helper.add` with math operations swapped for logical operations.
Uses inline ternary operators for state evaluation. 

----

cc @bigcommerce/storefront-team
