### PR TITLE
Create typeof.js

### DIFF
--- a/helpers/typeof.js
+++ b/helpers/typeof.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('./lib/common.js');
+
+const factory = globals => {
+    return function(data) {
+        data = common.unwrapIfSafeString(globals.handlebars, data);
+        return typeof data;
+    };
+};
+
+module.exports = [{
+    name: 'typeof',
+    factory: factory,
+}];


### PR DESCRIPTION
Add implementation of javascript "typeof".
Implementation is based on json.js call which will yield a inline string as a result.

Registration into helpers list is required if approved. https://github.com/bigcommerce/paper-handlebars/blob/master/helpers.js

## What? Why?
Function to determine type of provided input regardless of what the inline result is for use in if statements, and inline object construction. eg. of using in JSON.Parse string `{"value_type":"{{typeof variable}}"}`.
This also has the side effect that it will prevent needed to serialise objects in no-js environments to determine flow state via CSS selectors.

```CSS
[data-test-for-typeof="Number"] {
    display: hidden;
}
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof

## How was it tested?
Not tested. Based off existing file json.js with output line returning `typeof data` instead of `JSON.stringify(data)`.
----

cc @bigcommerce/storefront-team
