### PR TITLE
feat: Update jsonParseSafe.js - Inline use patch

### DIFF
--- a/helpers/jsonParseSafe.js
+++ b/helpers/jsonParseSafe.js
@@ -5,7 +5,10 @@ function factory(globals) {
     const options = arguments[arguments.length - 1];
 
     try {
-      return options.fn(JSON.parse(value));
+      if (options.fn) {
+        return options.fn(JSON.parse(value));
+      }
+      return JSON.parse(value);
     } catch (err) {
       return options.inverse(this);
     }

--- a/helpers/jsonParseSafe.js
+++ b/helpers/jsonParseSafe.js
@@ -13,7 +13,7 @@ function factory(globals) {
       if (options.fn) { // If function block {{#JSONparseSafe "{}"}} escape here on excaption.
         return options.inverse(this);
       }
-      return {}; // Escape hatch to avoid crash due to inline malformed JSON input.
+      return undefined; // Escape hatch to avoid crash due to inline malformed JSON input.
     }
   };
 }

--- a/helpers/jsonParseSafe.js
+++ b/helpers/jsonParseSafe.js
@@ -10,7 +10,10 @@ function factory(globals) {
       }
       return JSON.parse(value);
     } catch (err) {
-      return options.inverse(this);
+      if (options.fn) { // If function block {{#JSONparseSafe "{}"}} escape here on excaption.
+        return options.inverse(this);
+      }
+      return {}; // Escape hatch to avoid crash due to inline malformed JSON input.
     }
   };
 }

--- a/spec/helpers/jsonParseSafe.js
+++ b/spec/helpers/jsonParseSafe.js
@@ -9,7 +9,7 @@ describe('JSONParseSafe helper', () => {
     };
     const runTestCases = testRunner({context});
 
-    it('should execute the main instruction', done => {
+    it('#Block: should execute the main instruction', done => {
         runTestCases([
             {
                 input: '{{#JSONparseSafe jsonString}}{{name}}{{/JSONparseSafe}}',
@@ -18,7 +18,7 @@ describe('JSONParseSafe helper', () => {
         ], done);
     });
 
-    it('should skip the main instruction if variable is non-json', done => {
+    it('#Block: should skip the main instruction if variable is non-json', done => {
         runTestCases([
             {
                 input: '{{#JSONparseSafe string}}{{name}}{{/JSONparseSafe}}',
@@ -27,11 +27,68 @@ describe('JSONParseSafe helper', () => {
         ], done);
     });
 
-    it('should execute the else instruction if variable is non-json', done => {
+    it('#Block: should execute the else instruction if variable is non-json', done => {
         runTestCases([
             {
                 input: '{{#JSONparseSafe string}}{{name}}{{else}}{{string}}{{/JSONparseSafe}}',
                 output: 'John Doe',
+            },
+        ], done);
+    });
+
+    // Variation of the Block Helper test to convert to an Inline Call.
+    it('Inline: Output should match the same as `main test`', done => {
+        runTestCases([
+            {
+                input: '{{#with (JSONparseSafe jsonString)}}{{this.name}}{{/with}}',
+                output: 'John',
+            },
+        ], done);
+    });
+
+    it('Inline: Using JSON.stringify helper, and a empty object; parse the empty object and output it', done => {
+        runTestCases([
+            {
+                input: '{{#with (JSONparseSafe "{}")}}{{json this}}{{/with}}',
+                output: '{}',
+            },
+        ], done);
+    });
+
+
+    it('Inline: Using JSON.stringify helper, and a invalid / malformed object; parse the invalid object and output it, output is a Javascript `undefined` object', done => {
+        runTestCases([
+            {
+                input: '{{#with (JSONparseSafe "{")}}Undefined response due to malformed input{{else}}{{/with}}',
+                output: '',
+            },
+        ], done);
+    });
+
+    it('Inline: Stringifed example - with values', done => {
+        runTestCases([
+            {
+                input: `{{json (JSONparseSafe '{"test": "value"}')}}`,
+                output: "{&quot;test&quot;:&quot;value&quot;}",
+            },
+        ], done);
+    });
+
+
+    it('Inline: Stringifed example - without values', done => {
+        runTestCases([
+            {
+                input: `{{json (JSONparseSafe '{}')}}`,
+                output: '{}',
+            },
+        ], done);
+    });
+
+    it('Inline: Stringifed example - malformed input', done => {
+        runTestCases([
+            {
+                input: `{{json (JSONparseSafe '{')}}`,
+                output: '',
             },
         ], done);
     });


### PR DESCRIPTION
Add patch to allow for #JSONparseSafe to be used as a inline helper.

Examples:
`{{log (JSONparseSafe '{"test":"variable"}')}}`
`{{log (lookup (JSONparseSafe '{"test":{"validate":"variable"}}') "test")}}`

## What? Why?
To prevent this situation which makes code so much harder to maintain and reason with:
```Handlebars
{{! Pretend at this layer there is a pagination object here }}

{{! Before}}
{{#JSONparseSafe '{"test": "hello world!"}'}}
    {{#with this}}
        {{log test}}
        {{log ../../pagination}}
    {{/with}}
{{/JSONparseSafe}}


{{! After}}
{{#with (JSONparseSafe '{"test": "hello world!"}')}}
    {{log test}}
    {{log ../pagination}}
{{/with}}
```

This change removes a extra layer of context shifting `( ../ )` to access information about the context window.

## How was it tested?
Local tests, modified local theme testing file.
----

cc @bigcommerce/storefront-team
