### PR TITLE
Update object.js - Inline use of JSONparse patch

### DIFF
--- a/helpers/3p/object.js
+++ b/helpers/3p/object.js
@@ -194,7 +194,10 @@ helpers.merge = function(context/*, objects, options*/) {
  */
 
 helpers.JSONparse = function(str, options) {
-  return options.fn(JSON.parse(str));
+  if (options.fn) {
+    return options.fn(JSON.parse(str));
+  }
+  return JSON.parse(str);
 };
 
 /**


### PR DESCRIPTION
Add patch to allow for #JSONparse to be used as a inline helper.

*This is a feature parody patch to align use case with proposed change for `JSONparseSafe` helper. #341 

Examples:
`{{log (JSONparse '{"test":"variable"}')}}`
`{{log (lookup (JSONparse '{"test":{"validate":"variable"}}') "test")}}`

## What? Why?
To prevent this situation which makes code so much harder to maintain and reason with:
```Handlebars
{{! Pretend at this layer there is a pagination object here }}

{{! Before}}
{{#JSONparse '{"test": "hello world!"}'}}
    {{#with this}}
        {{log test}}
        {{log ../../pagination}}
    {{/with}}
{{/JSONparse}}


{{! After}}
{{#with (JSONparse '{"test": "hello world!"}')}}
    {{log test}}
    {{log ../pagination}}
{{/with}}
```

This change removes a extra layer of context shifting `( ../ )` to access information about the context window.

## How was it tested?
Local tests, modified local theme testing file.
----

cc @bigcommerce/storefront-team
