### PR TITLE
feat(assignVar): Patch for assignVar to add "drop key" feature and fixes reflecting documentation

### DIFF
--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -7,12 +7,12 @@ const common = require("./lib/common");
 
 const factory = globals => {
     return function (key, value) {
+        globals.getLogger().info(`DEBUG assignVar helper called with key: ${key} and value: ${value}`);
 
         // Validate that key is a string
         if (!utils.isString(key)) {
             throw new ValidationError("assignVar helper key must be a string");
         }
-
 
         // Setup storage
         if (typeof globals.storage.variables === 'undefined') {
@@ -30,7 +30,7 @@ const factory = globals => {
                 throw new ValidationError("assignVar helper value must be a string or a number (integer/float)");
             }
 
-            // Validate that string is not longer than the max length
+            // Validate that string is not longer than or equal to the max length
             if (utils.isString(value) && value.length >= max_length) {
                 throw new ValidationError(`assignVar helper value must be less than ${max_length} characters, 
                 but a ${value.length} character value was set to ${key}`);
@@ -53,4 +53,6 @@ const factory = globals => {
 module.exports = [{
     name: 'assignVar',
     factory: factory,
+    max_length: max_length,
+    max_keys: max_keys
 }];

--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -12,29 +12,36 @@ const factory = globals => {
             throw new ValidationError("assignVar helper key must be a string");
         }
 
-        // Validate that value is a string or Number (int/float)
-        if (!utils.isString(value) && !Number.isFinite(value)) {
-            throw new ValidationError("assignVar helper value must be a string or a number (integer/float)");
-        }
+        //Check for if the assigned value is being set to null or undefined
+        if (!(value === null || value === undefined)) {
 
-        // Validate that string is not longer than the max length
-        if (utils.isString(value) && value.length >= max_length) {
-            throw new ValidationError(`assignVar helper value must be less than ${max_length} characters, 
+            // Validate that value is a string or Number (int/float)
+            if (!(utils.isString(value) || value === "") && !Number.isFinite(value)) {
+                throw new ValidationError("assignVar helper value must be a string or a number (integer/float)");
+            }
+
+            // Validate that string is not longer than the max length
+            if (utils.isString(value) && value.length >= max_length) {
+                throw new ValidationError(`assignVar helper value must be less than ${max_length} characters, 
                 but a ${value.length} character value was set to ${key}`);
-        }
+            }
 
-        // Setup storage
-        if (typeof globals.storage.variables === 'undefined') {
-            globals.storage.variables = Object.create(null);
-        }
+            // Setup storage
+            if (typeof globals.storage.variables === 'undefined') {
+                globals.storage.variables = Object.create(null);
+            }
 
-        // Make sure the number of total keys is within the limit
-        if (Object.keys(globals.storage.variables).length >= max_keys) {
-            throw new ValidationError(`Unique keys in variable storage may not exceed ${max_keys} in total`);
-        }
+            // Make sure the number of total keys is within the limit
+            if (Object.keys(globals.storage.variables).length >= max_keys) {
+                throw new ValidationError(`Unique keys in variable storage may not exceed ${max_keys} in total`);
+            }
 
-        // Store value for later use by getVar helper
-        globals.storage.variables[key] = value;
+            // Store value for later use by getVar helper
+            globals.storage.variables[key] = value;
+        } else {
+            // Delete value from storage as it is now unset.
+            delete globals.storage.variables[key];
+        }
     };
 };
 

--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -36,7 +36,7 @@ const factory = globals => {
             }
 
             // Make sure the number of total keys is within the limit
-            if (Object.keys(globals.storage.variables).length > max_keys) {
+            if (Object.keys(globals.storage.variables).length >= max_keys) {
                 throw new ValidationError(`Unique keys in variable storage may not exceed ${max_keys} in total`);
             }
 

--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -3,6 +3,7 @@ const utils = require('./3p/utils');
 const max_length = 1024;
 const max_keys = 50;
 const { ValidationError } = require('../lib/errors');
+const common = require("./lib/common");
 
 const factory = globals => {
     return function (key, value) {
@@ -12,8 +13,17 @@ const factory = globals => {
             throw new ValidationError("assignVar helper key must be a string");
         }
 
+
+        // Setup storage
+        if (typeof globals.storage.variables === 'undefined') {
+            globals.storage.variables = Object.create(null);
+        }
+
         //Check for if the assigned value is being set to null or undefined
         if (!(value === null || value === undefined)) {
+
+            // Due to check for string length, we need to unwrap Handlebars.SafeString
+            value = common.unwrapIfSafeString(globals.handlebars, value);
 
             // Validate that value is a string or Number (int/float)
             if (!(utils.isString(value) || value === "") && !Number.isFinite(value)) {
@@ -24,11 +34,6 @@ const factory = globals => {
             if (utils.isString(value) && value.length >= max_length) {
                 throw new ValidationError(`assignVar helper value must be less than ${max_length} characters, 
                 but a ${value.length} character value was set to ${key}`);
-            }
-
-            // Setup storage
-            if (typeof globals.storage.variables === 'undefined') {
-                globals.storage.variables = Object.create(null);
             }
 
             // Make sure the number of total keys is within the limit

--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -7,7 +7,7 @@ const common = require("./lib/common");
 
 const factory = globals => {
     return function (key, value) {
-        globals.getLogger().info(`DEBUG assignVar helper called with key: ${key} and value: ${value}`);
+        //globals.getLogger().info(`DEBUG assignVar helper called with key: ${key} and value: ${value}`);
 
         // Validate that key is a string
         if (!utils.isString(key)) {
@@ -53,6 +53,7 @@ const factory = globals => {
 module.exports = [{
     name: 'assignVar',
     factory: factory,
+    // Expose for use in testing to prevent magic numbers that can de-sync.
     max_length: max_length,
     max_keys: max_keys
 }];

--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -7,7 +7,6 @@ const common = require("./lib/common");
 
 const factory = globals => {
     return function (key, value) {
-        //globals.getLogger().info(`DEBUG assignVar helper called with key: ${key} and value: ${value}`);
 
         // Validate that key is a string
         if (!utils.isString(key)) {
@@ -37,7 +36,7 @@ const factory = globals => {
             }
 
             // Make sure the number of total keys is within the limit
-            if (Object.keys(globals.storage.variables).length >= max_keys) {
+            if (Object.keys(globals.storage.variables).length > max_keys) {
                 throw new ValidationError(`Unique keys in variable storage may not exceed ${max_keys} in total`);
             }
 

--- a/spec/helpers/assignVar-getVar.js
+++ b/spec/helpers/assignVar-getVar.js
@@ -5,15 +5,25 @@ const Lab = require('lab'),
     specHelpers = require('../spec-helpers'),
     testRunner = specHelpers.testRunner,
     renderString = specHelpers.renderString;
-
+const AssignVarHelper = require('../../helpers/assignVar')[0];
 
 describe('assignVar and getVar helpers', function() {
+
+    const generateOverflowString = (length, char) => {
+        return `${[...Array(length).keys()].map(_=>char).join("")}`;
+    }
+
     const context = {
         value1: "Big",
         value2: "Commerce",
         value3: 12,
         value4: -12.34,
-        value1300char: "rOiWsgkWKLRm0fve752Upp7qe3QBNBlKaSgMJaG6zbB8TChtbxLfnEbidd6GiJdjm5Q18LDwy24zQxjOpGKqVzbg3cyEh5vwSZvdwl34EMXM8Iqa3QTP2aEXCBhpnoTBBv4USIPU3dmyNRL7Gmx63TyBkVCqrjXZ033KhrDXrGmE9eVGpzNktFxpAiylJHFnQmehKFnsPn5fbicfDChGhTbu3hk4ti9tvmawWziljUmqdGQ8ddovJ2ivz0fSfoC5UoBTOMU4xNJfupFunE1ayncImLJUnDCW1hWC99Qb2AVAMNCzH84V3Pch0cERhxYed87Aw1rH4tMOLBnnOWF6KYDd5hGQLWaSMiv2kS5PHiAfcndquARxnSrAxGY01ly3bSLivoW98AD7poZXb61Skuiw5wSd6rAfr2WXRTlaQWsyJ3r5qqtmg9k5LwH9p76FMKYDOFtf0tqE8nK0ZoSBesASojH3aNLEV9Ad8zXBIv5euClEwDs54aWtYgnAZt1fBz9pDmcwMi32YrHcYDHM2HGDkdfjaGpEsPzvlipBRveXQwmwgxzqNlXoQT98vPSFXKm8WC2dQkcCt8XbMEr5gk37UJNoqhcaAp7vKCentu1iO8y80aN2ggzJ14tHTk5zYpvtk2gplkh6yWri9z99FpHpWoXIHH37EEGaw9KmRju5Gb7GK4HsDhQmkxUajdpcWZGneNQEbQ0kHd3iPaTzioJJ1tLoi4qRoTvttahwIcuxFtOXi6mg6dE60RtlZUPDn8MLsA7o7Ofu6uuzktP8ZyafhmC1YVAO5GPxSi9DAbtAC8EkWFNkD6ZGJdPWCbSGNVjfMwZ5Jn4Y9MpV3hF4wuTj2HLdSmhq0SO9npznJpXX38N6mgMoW9OOSKa2meGT7IzqAH4hzjagHJoKjVz0N06TO5jclv72nyHXv9tfQHyrT5HAHDCWvmqvDKmqyJlmZ78bZLa8CyE1CChqjtI6lhsf2grHw7sHE0wmA3K3TbQuAg1DHxhHZtUzoDHj8JBrW3iSACljFu8KBGnBVEdVV9amvLaZSj466sougBQUcpjfkPKeig7iqJmzqBhA2WXZ03qXoIioCQFxbUuZJ7H53LtK8AbB9Nou8E0eChhEnTE69K3R9g15I8zD8xvFQvat8h62Ac0UBj4SqOvpYwtK0yXY3a87kK341KA7pFH99k0SRtUxAUHSYwnhvSAYHe2oZyDUxoQbF3ElbF68cMWbFB39x40lnKKxV0V6T97JI2lDivSH4r6sJV416P5xh7a21q20gwEmAfEBKSQ20i5f",
+        valueUnderStringBuffer: generateOverflowString(AssignVarHelper.max_length-1, "U"),
+        // Bug in testing suite, strings in context that are over or equal to the max length are not being sent to the
+        // helpers. instead an `undefined` is being sent. To handle this we can use a template string in the tests
+        // directly to pretend that the string is being sent to the helpers.
+        valueFillStringBuffer: generateOverflowString(AssignVarHelper.max_length, "F"),
+        valueOverflowStringBufferBy1: generateOverflowString(AssignVarHelper.max_length+1, "O"),
         valueEmptyString: "",
         valueNull: null,
         valueEncodedSafeString: "<script>alert('XSS')</script>",
@@ -62,6 +72,20 @@ describe('assignVar and getVar helpers', function() {
                 input: "{{assignVar 'data1' value1}}{{assignVar 'data2' value2}}{{getVar 'data1'}}{{getVar 'data2'}}",
                 output: 'BigCommerce',
             },
+            {
+                input: "{{assignVar 'data1' null}}{{assignVar 'data2' undefined}}{{getVar 'data1'}}{{getVar 'data2'}}",
+                output: '',
+            },
+        ], done);
+    });
+
+    // Check to see if the assignVar still works when the situation is that no data has been stored yet, and a delete instruction is given.
+    it('should accept null and undefined as input before any variables are stored', function(done) {
+        runTestCases([
+            {
+                input: "{{assignVar 'data1' null}}{{assignVar 'data2' undefined}}{{getVar 'data1'}}{{getVar 'data2'}}",
+                output: '',
+            },
         ], done);
     });
 
@@ -96,7 +120,6 @@ describe('assignVar and getVar helpers', function() {
         ], done);
     });
 
-
     it('should accept a "SafeString" object as a valid alternative to a string (results should be a string when stored)', function(done) {
         runTestCases([
             {
@@ -106,11 +129,34 @@ describe('assignVar and getVar helpers', function() {
         ], done);
     });
 
-    it('should throw an error if too long of a value is used', function(done) {
-        renderString("{{assignVar 'data1' value1300char}}").catch(e => {
-            done();
-        });
+    it(`should accept a string up to the maximum length of the buffer (Max length: ${AssignVarHelper.max_length})`, function(done) {
+        runTestCases([
+            {
+                input: "{{assignVar 'data1' valueUnderStringBuffer}}{{getVar 'data1'}}",
+                output: `${context.valueUnderStringBuffer}`,
+            },
+        ], done);
     });
+
+    it(`should throw an error if buffer is filled (Max length: ${AssignVarHelper.max_length})`,
+        function(done) {
+            renderString(`{{assignVar "fill" "${context.valueFillStringBuffer}"}}`).catch(e => {
+                // If inline injection of string is not done, the test will fail when it should pass via the catch.
+                // See context above for more information.
+                done();
+            });
+        }
+    );
+
+    it(`should throw an error if buffer is overflowed (Max length: ${AssignVarHelper.max_length})`,
+        function(done) {
+            renderString(`{{assignVar 'overflow' "${context.valueOverflowStringBufferBy1}"}}`).catch(e => {
+                // If inline injection of string is not done, the test will fail when it should pass via the catch.
+                // See context above for more information.
+                done();
+            });
+        }
+    );
 
     it('should return undefined accessing proto/constructor', function(done) {
         runTestCases([

--- a/spec/helpers/assignVar-getVar.js
+++ b/spec/helpers/assignVar-getVar.js
@@ -14,6 +14,8 @@ describe('assignVar and getVar helpers', function() {
         value3: 12,
         value4: -12.34,
         value1300char: "rOiWsgkWKLRm0fve752Upp7qe3QBNBlKaSgMJaG6zbB8TChtbxLfnEbidd6GiJdjm5Q18LDwy24zQxjOpGKqVzbg3cyEh5vwSZvdwl34EMXM8Iqa3QTP2aEXCBhpnoTBBv4USIPU3dmyNRL7Gmx63TyBkVCqrjXZ033KhrDXrGmE9eVGpzNktFxpAiylJHFnQmehKFnsPn5fbicfDChGhTbu3hk4ti9tvmawWziljUmqdGQ8ddovJ2ivz0fSfoC5UoBTOMU4xNJfupFunE1ayncImLJUnDCW1hWC99Qb2AVAMNCzH84V3Pch0cERhxYed87Aw1rH4tMOLBnnOWF6KYDd5hGQLWaSMiv2kS5PHiAfcndquARxnSrAxGY01ly3bSLivoW98AD7poZXb61Skuiw5wSd6rAfr2WXRTlaQWsyJ3r5qqtmg9k5LwH9p76FMKYDOFtf0tqE8nK0ZoSBesASojH3aNLEV9Ad8zXBIv5euClEwDs54aWtYgnAZt1fBz9pDmcwMi32YrHcYDHM2HGDkdfjaGpEsPzvlipBRveXQwmwgxzqNlXoQT98vPSFXKm8WC2dQkcCt8XbMEr5gk37UJNoqhcaAp7vKCentu1iO8y80aN2ggzJ14tHTk5zYpvtk2gplkh6yWri9z99FpHpWoXIHH37EEGaw9KmRju5Gb7GK4HsDhQmkxUajdpcWZGneNQEbQ0kHd3iPaTzioJJ1tLoi4qRoTvttahwIcuxFtOXi6mg6dE60RtlZUPDn8MLsA7o7Ofu6uuzktP8ZyafhmC1YVAO5GPxSi9DAbtAC8EkWFNkD6ZGJdPWCbSGNVjfMwZ5Jn4Y9MpV3hF4wuTj2HLdSmhq0SO9npznJpXX38N6mgMoW9OOSKa2meGT7IzqAH4hzjagHJoKjVz0N06TO5jclv72nyHXv9tfQHyrT5HAHDCWvmqvDKmqyJlmZ78bZLa8CyE1CChqjtI6lhsf2grHw7sHE0wmA3K3TbQuAg1DHxhHZtUzoDHj8JBrW3iSACljFu8KBGnBVEdVV9amvLaZSj466sougBQUcpjfkPKeig7iqJmzqBhA2WXZ03qXoIioCQFxbUuZJ7H53LtK8AbB9Nou8E0eChhEnTE69K3R9g15I8zD8xvFQvat8h62Ac0UBj4SqOvpYwtK0yXY3a87kK341KA7pFH99k0SRtUxAUHSYwnhvSAYHe2oZyDUxoQbF3ElbF68cMWbFB39x40lnKKxV0V6T97JI2lDivSH4r6sJV416P5xh7a21q20gwEmAfEBKSQ20i5f",
+        valueEmptyString: "",
+        valueNull: null,
     };
 
     const runTestCases = testRunner({context});
@@ -32,6 +34,21 @@ describe('assignVar and getVar helpers', function() {
 
     it('should assign and get variables', function(done) {
         runTestCases([
+            {
+                // New test case: Assigning a variable with an empty string value
+                input: "{{assignVar 'data1' valueEmptyString}}{{getVar 'data1'}}",
+                output: '',
+            },
+            {
+                // New test case: Assigning a variable with a string value, then delete it by assigning null
+                input: "{{assignVar 'data1' value1}}{{getVar 'data1'}} {{assignVar 'data1' null}}{{getVar 'data1'}} {{assignVar 'data1' value1}}{{getVar 'data1'}} {{assignVar 'data1' valueNull}}{{getVar 'data1'}}",
+                output: 'Big  Big ',
+            },
+            {
+                // New test case: Assigning a variable with a string value, then delete it by assigning undefined
+                input: "{{assignVar 'data1' value1}}{{getVar 'data1'}} {{assignVar 'data1' undefined}}{{getVar 'data1'}}",
+                output: 'Big ',
+            },
             {
                 input: "{{assignVar 'data1' value1}}{{assignVar 'data2' 12}}{{getVar 'data1'}} {{getVar 'data2'}}",
                 output: 'Big 12',

--- a/spec/helpers/assignVar-getVar.js
+++ b/spec/helpers/assignVar-getVar.js
@@ -16,6 +16,7 @@ describe('assignVar and getVar helpers', function() {
         value1300char: "rOiWsgkWKLRm0fve752Upp7qe3QBNBlKaSgMJaG6zbB8TChtbxLfnEbidd6GiJdjm5Q18LDwy24zQxjOpGKqVzbg3cyEh5vwSZvdwl34EMXM8Iqa3QTP2aEXCBhpnoTBBv4USIPU3dmyNRL7Gmx63TyBkVCqrjXZ033KhrDXrGmE9eVGpzNktFxpAiylJHFnQmehKFnsPn5fbicfDChGhTbu3hk4ti9tvmawWziljUmqdGQ8ddovJ2ivz0fSfoC5UoBTOMU4xNJfupFunE1ayncImLJUnDCW1hWC99Qb2AVAMNCzH84V3Pch0cERhxYed87Aw1rH4tMOLBnnOWF6KYDd5hGQLWaSMiv2kS5PHiAfcndquARxnSrAxGY01ly3bSLivoW98AD7poZXb61Skuiw5wSd6rAfr2WXRTlaQWsyJ3r5qqtmg9k5LwH9p76FMKYDOFtf0tqE8nK0ZoSBesASojH3aNLEV9Ad8zXBIv5euClEwDs54aWtYgnAZt1fBz9pDmcwMi32YrHcYDHM2HGDkdfjaGpEsPzvlipBRveXQwmwgxzqNlXoQT98vPSFXKm8WC2dQkcCt8XbMEr5gk37UJNoqhcaAp7vKCentu1iO8y80aN2ggzJ14tHTk5zYpvtk2gplkh6yWri9z99FpHpWoXIHH37EEGaw9KmRju5Gb7GK4HsDhQmkxUajdpcWZGneNQEbQ0kHd3iPaTzioJJ1tLoi4qRoTvttahwIcuxFtOXi6mg6dE60RtlZUPDn8MLsA7o7Ofu6uuzktP8ZyafhmC1YVAO5GPxSi9DAbtAC8EkWFNkD6ZGJdPWCbSGNVjfMwZ5Jn4Y9MpV3hF4wuTj2HLdSmhq0SO9npznJpXX38N6mgMoW9OOSKa2meGT7IzqAH4hzjagHJoKjVz0N06TO5jclv72nyHXv9tfQHyrT5HAHDCWvmqvDKmqyJlmZ78bZLa8CyE1CChqjtI6lhsf2grHw7sHE0wmA3K3TbQuAg1DHxhHZtUzoDHj8JBrW3iSACljFu8KBGnBVEdVV9amvLaZSj466sougBQUcpjfkPKeig7iqJmzqBhA2WXZ03qXoIioCQFxbUuZJ7H53LtK8AbB9Nou8E0eChhEnTE69K3R9g15I8zD8xvFQvat8h62Ac0UBj4SqOvpYwtK0yXY3a87kK341KA7pFH99k0SRtUxAUHSYwnhvSAYHe2oZyDUxoQbF3ElbF68cMWbFB39x40lnKKxV0V6T97JI2lDivSH4r6sJV416P5xh7a21q20gwEmAfEBKSQ20i5f",
         valueEmptyString: "",
         valueNull: null,
+        valueEncodedSafeString: "<script>alert('XSS')</script>",
     };
 
     const runTestCases = testRunner({context});
@@ -91,6 +92,16 @@ describe('assignVar and getVar helpers', function() {
             {
                 input: "{{assignVar 'data1' value3}}{{assignVar 'data2' 10}}{{getVar 'data1'}} + {{getVar 'data2'}} = {{add (getVar 'data1') (getVar 'data2')}}",
                 output: '12 + 10 = 22',
+            },
+        ], done);
+    });
+
+
+    it('should accept a "SafeString" object as a valid alternative to a string (results should be a string when stored)', function(done) {
+        runTestCases([
+            {
+                input: "{{assignVar 'data1' (encodeHtmlEntities valueEncodedSafeString)}}{{getVar 'data1'}}",
+                output: '&amp;#x3C;script&amp;#x3E;alert(&amp;#x27;XSS&amp;#x27;)&amp;#x3C;/script&amp;#x3E;', // SAY NO TO XSS
             },
         ], done);
     });


### PR DESCRIPTION
## Proposal, What? Why?

Helper `assignVar` currently does not have a way to do any of the following features:
1. Un-Map a assigned value: once a key has been set, it is locked for the whole render pipeline. This results in features like widgets taking up half of the available variables only to use them once and never again, limiting theme developers from being able to add new features due to limited variable space.
2. Accept an empty string into a variable as its value. Given a string is valid input, all states of a string should be considered as valid, limited by length. For instance, if a variable is set to `""` because it is intended to be a placeholder when a value is not provided by the store admins or a customer input, say for a phone number click to call, this will currently cause the store to err.500 instead of handling what should be a valid input. The data input is inherently reasonable, so there is a patch in the validation logic to accept an empty string value instead of rejecting it.
3. Ingest a `SafeString` object and treat it like a actual string for purposes of storage and retreival. Current workaround possible as per open issue #139

## Changes Overview
Create patch for assignVar to add following features:
- Empty string ( "" ) to be accepted as entry into assignVar helper. 
- Null or Undefined values as input to assignVar now delete the key that was set. This has the use-case of freeing variables assigned by widgets or temporary assignments.
- Internal conversion via `unwrapSafeString` call before variable is process to all for storage and retrieval of `SafeString` contents.
- Tests for these use-cases in assignVar-getVar.js


## How was it tested?
Test cases provided in `assignVar-getVar.js` file.

----

cc @bigcommerce/storefront-team
