### PR TITLE
fix: STRF-13111 Object.create(null) insted of empty object

### DIFF
--- a/helpers/assignVar.js
+++ b/helpers/assignVar.js
@@ -25,7 +25,7 @@ const factory = globals => {
 
         // Setup storage
         if (typeof globals.storage.variables === 'undefined') {
-            globals.storage.variables = {};
+            globals.storage.variables = Object.create(null);
         }
 
         // Make sure the number of total keys is within the limit

--- a/helpers/decrementVar.js
+++ b/helpers/decrementVar.js
@@ -12,7 +12,7 @@ const factory = globals => {
 
         // Setup storage
         if (typeof globals.storage.variables === 'undefined') {
-            globals.storage.variables = {};
+            globals.storage.variables = Object.create(null);
         }
 
         if (Object.hasOwnProperty.call(globals.storage.variables, key) && Number.isInteger(globals.storage.variables[key])) {

--- a/helpers/incrementVar.js
+++ b/helpers/incrementVar.js
@@ -12,7 +12,7 @@ const factory = globals => {
 
         // Setup storage
         if (typeof globals.storage.variables === 'undefined') {
-            globals.storage.variables = {};
+            globals.storage.variables = Object.create(null);
         }
 
         if (Object.hasOwnProperty.call(globals.storage.variables, key) && Number.isInteger(globals.storage.variables[key])) {

--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -8,7 +8,7 @@ const factory = globals => {
 
         // Setup storage
         if (typeof globals.storage.inject === 'undefined') {
-            globals.storage.inject = {};
+            globals.storage.inject = Object.create(null);
         }
 
         // Store value for later use by jsContext

--- a/spec/helpers/decrementVar.js
+++ b/spec/helpers/decrementVar.js
@@ -59,7 +59,7 @@ describe('decrementVar helper', function() {
         runTestCases([
             {
                 input: "{{decrementVar '__proto__'}}",
-                output: '',
+                output: '0',
             },
             {
                 input: "{{decrementVar 'constructor'}}",

--- a/spec/helpers/incrementVar.js
+++ b/spec/helpers/incrementVar.js
@@ -61,7 +61,7 @@ describe('incrementVar helper', function() {
         runTestCases([
             {
                 input: "{{incrementVar '__proto__'}}",
-                output: '',
+                output: '0',
             },
             {
                 input: "{{incrementVar 'constructor'}}",


### PR DESCRIPTION
## What? Why?

- Object.create(null) insted of {}

## How was it tested?

npm test 

----

cc @bigcommerce/storefront-team
