### PR TITLE
ci: enable windows as OS for running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        node: [20.x, 22.x]
+        matrix:
+            node: [20.x, 22.x]
+            os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     env:
       TITLE: ${{ github.event.pull_request.title }}
 
@@ -28,6 +27,7 @@ jobs:
         run: npm i
 
       - name: Verify Github PR Title
+        shell: bash
         run: echo $TITLE | npx commitlint
 
       - name: Verify Git Commit Name 

--- a/spec/helpers/dynamicComponent.js
+++ b/spec/helpers/dynamicComponent.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const Lab = require('lab'),
       lab = exports.lab = Lab.script(),
       describe = lab.experiment,
@@ -6,9 +7,9 @@ const Lab = require('lab'),
 
 describe('dynamicComponent helper', function() {
     const templates = {
-              'component/fields/one': '1{{animal}}',
-              'component/fields/two': '2{{animal}}',
-              'component/fields/three': '3{{animal}}',
+              [path.normalize('component/fields/one')]: '1{{animal}}',
+              [path.normalize('component/fields/two')]: '2{{animal}}',
+              [path.normalize('component/fields/three')]: '3{{animal}}',
           },
           context = {
               fields: [


### PR DESCRIPTION
## What? Why?

- Enable windows and ubuntu for the pipeline
- Fix dynamicComponent test for windows

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
