### PR TITLE
fix: STRF-13182 disable log helper for rendering services

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,8 @@ class HandlebarsRenderer {
             const spec = helpers[i];
             this.handlebars.registerHelper(spec.name, spec.factory(this.helperContext));
         }
+
+        this.overrideHelpers();
     }
 
     getResourceHints() {
@@ -417,6 +419,12 @@ class HandlebarsRenderer {
      */
     setLoggerLevel(level) {
         this.handlebars.logger.level = level;
+    }
+
+    overrideHelpers() {
+        if (this.isLoggerOverriden) {
+            this.handlebars.registerHelper('log', () => undefined);
+        }
     }
 }
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -439,7 +439,7 @@ describe('logging', () => {
     it('log helper uses given logger', done => {
         renderer = new HandlebarsRenderer({}, {}, 'v3', logger);
         renderer.renderString('{{log bar}}', context).then(() => {
-            expect(logger.info.calledWith('baz')).to.equal(true);
+            expect(logger.info.called).to.equal(false);
             done();
         });
     });
@@ -519,6 +519,7 @@ describe('logging', () => {
         expect(result).to.equal("");
         expect(logger.info.calledWith('Handlebars: Access has been denied to resolve the property "trim" because it is not an "own property" of its parent.\n' + 'You can add a runtime option to disable the check or this warning:\n' + 'See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details'))
             .to.equal(true);
+   
     });
 
     it('should check that property access denied message is set as error', async () => {


### PR DESCRIPTION
## What? Why?

Disable log helper for rendering services

More [here](https://github.com/bigcommerce/storefront-renderer-2/pull/155)

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
