### PR TITLE
fix: set chrono-node to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/bigcommerce/paper-handlebars",
   "dependencies": {
     "@bigcommerce/handlebars-v4": "4.7.8",
-    "chrono-node": "^2.6.5",
+    "chrono-node": "2.8.0",
     "handlebars": "3.0.8",
     "he": "^1.2.0",
     "moment": "^2.29.4",


### PR DESCRIPTION
## What? Why?
set chrono-node version to 2.8.0 as 2.8.1 is not a working version

## How was it tested?
npm test

----

cc @bigcommerce/storefront-team
