### PR TITLE
feat: TRAC-642 Expose Handlebars v3 runtime option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const HandlebarsV3 = require('handlebars');
+const HandlebarsV3Runtime = require('handlebars/runtime.js');
 const HandlebarsV4 = require('@bigcommerce/handlebars-v4');
 const HandlebarsV4Runtime = require('@bigcommerce/handlebars-v4').runtime;
 const helpers = require('./helpers');
@@ -42,6 +43,9 @@ class HandlebarsRenderer {
         switch(hbVersion) {
             case 'v4-runtime':
                 this.handlebars = HandlebarsV4Runtime;
+                break;
+            case 'v3-runtime':
+                this.handlebars = HandlebarsV3Runtime;
                 break;
             case 'v4':
                 this.handlebars = HandlebarsV4.create();


### PR DESCRIPTION
## What? Why?
Exposes the Handlebars v3 runtime as a selectable renderer via the `v3-runtime` `hbVersion` option, mirroring the existing `v4-runtime` support added in #391.


## How was it tested?

Cloudflare Workers

----

cc @bigcommerce/storefront-team

[TRAC-642]: https://bigcommercecloud.atlassian.net/browse/TRAC-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ