### PR TITLE
fix(TRAC-875): preserve ValidationError type in render/renderString

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,6 +320,9 @@ class HandlebarsRenderer {
             try {
                 result = template(context);
             } catch(e) {
+                if (e instanceof ValidationError) {
+                    return reject(new ValidationError(`${e.message} : ${e.stack}`));
+                }
                 return reject(new RenderError(`${e.message} : ${e.stack}`));
             }
 
@@ -372,6 +375,9 @@ class HandlebarsRenderer {
             try {
                 result = template(context);
             } catch(e) {
+                if (e instanceof ValidationError) {
+                    return reject(new ValidationError(`${e.message} : ${e.stack}`));
+                }
                 return reject(new RenderError(`${e.message} : ${e.stack}`));
             }
 

--- a/spec/index.js
+++ b/spec/index.js
@@ -233,6 +233,7 @@ describe('render', () => {
         'capitalize_foo': '{{capitalize bar}}',
         'with_locale': '{{locale_name}}',
         'with_template': '{{template}}',
+        'assign_var_too_long': '{{assignVar "foo" longString}}',
     };
     const context = {
         bar: 'baz'
@@ -325,6 +326,16 @@ describe('render', () => {
             done();
         });
     });
+
+    it('throws ValidationError (not RenderError) if a helper rejects its input, formatted like RenderError', done => {
+        renderer.render('assign_var_too_long', { longString: 'a'.repeat(1024) }).catch(e => {
+            expect(e instanceof HandlebarsRenderer.errors.ValidationError).to.be.true();
+            expect(e instanceof HandlebarsRenderer.errors.RenderError).to.be.false();
+            expect(e.message).to.include('assignVar helper value must be less than 1024 characters');
+            expect(e.message).to.include(' : ');
+            done();
+        });
+    });
 });
 
 describe('renderString', () => {
@@ -375,6 +386,16 @@ describe('renderString', () => {
     it('throws PrecompileError if given malformed template', done => {
         renderer.renderString('{{', context).catch(e => {
             expect(e instanceof HandlebarsRenderer.errors.PrecompileError).to.be.true();
+            done();
+        });
+    });
+
+    it('throws ValidationError (not RenderError) if a helper rejects its input, formatted like RenderError', done => {
+        renderer.renderString('{{assignVar "foo" longString}}', { longString: 'a'.repeat(1024) }).catch(e => {
+            expect(e instanceof HandlebarsRenderer.errors.ValidationError).to.be.true();
+            expect(e instanceof HandlebarsRenderer.errors.RenderError).to.be.false();
+            expect(e.message).to.include('assignVar helper value must be less than 1024 characters');
+            expect(e.message).to.include(' : ');
             done();
         });
     });


### PR DESCRIPTION
Jira: [TRAC-875](https://bigcommercecloud.atlassian.net/browse/TRAC-875)

## What? Why?

- Helper input-validation errors (e.g. `assignVar` rejecting values >1024 chars) were wrapped as `RenderError`, losing the original `ValidationError` type
- Downstream consumers need to tell "client/theme input fault" apart from "generic render failure" to map the former to a 4xx instead of 500
- `render()`/`renderString()` now re-throw `ValidationError` as-is instead of wrapping it
- No change to helpers or to `ValidationError` itself

Part of a 3-repo change (paper-handlebars → storefront-renderer-2 → storefront) downgrading these errors from 500 to 4xx.

## How was it tested?

- Added specs asserting a helper `ValidationError` is rejected as `ValidationError` (not `RenderError`) from both `render()` and `renderString()`
- Full suite passes (53/53)

[TRAC-875]: https://bigcommercecloud.atlassian.net/browse/TRAC-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ