### PR TITLE
fix(deps): replace @bigcommerce/handlebars-v4 with npm alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const HandlebarsV3 = require('handlebars');
 const HandlebarsV3Runtime = require('handlebars/runtime.js');
-const HandlebarsV4 = require('@bigcommerce/handlebars-v4');
-const HandlebarsV4Runtime = require('@bigcommerce/handlebars-v4').runtime;
+const HandlebarsV4 = require('handlebars-v4');
+const HandlebarsV4Runtime = require('handlebars-v4/runtime.js');
 const helpers = require('./helpers');
 
 const AppError = require('./lib/appError');

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "homepage": "https://github.com/bigcommerce/paper-handlebars",
   "dependencies": {
-    "@bigcommerce/handlebars-v4": "4.8.1",
     "chrono-node": "2.8.0",
     "handlebars": "3.0.8",
+    "handlebars-v4": "npm:handlebars@4.7.9",
     "he": "^1.2.0",
     "moment": "^2.29.4",
     "remarkable": "^2.0.1",

--- a/spec/helpers/3p/utils/lib/createFrame.js
+++ b/spec/helpers/3p/utils/lib/createFrame.js
@@ -7,7 +7,7 @@ const describe = lab.describe;
 
 const createFrame = require('../../../../../helpers/3p/utils/lib/createFrame');
 
-var hbs = require('@bigcommerce/handlebars-v4');
+var hbs = require('handlebars-v4');
 
 describe('createFrame', function () {
   it('should create a reference to _parent:', function (done) {


### PR DESCRIPTION
Jira: [TRAC-961](https://bigcommercecloud.atlassian.net/browse/TRAC-961) (LTRAC-993)

## What? Why?

- Replace the `@bigcommerce/handlebars-v4` wrapper dependency with an npm alias: `handlebars-v4` → `handlebars@4.7.9` (same version the wrapper pinned).
- The wrapper package existed only to load Handlebars v3 and v4 side by side under distinct names. Modern npm alias support (`npm:handlebars@4`) does this with no separately published package — same pattern already used for v3 in `stencil-renderer-worker`.
- Runtime now imports the `handlebars-v4/runtime.js` subpath. The bare `handlebars` export has no `.runtime` property; only the old wrapper added it.
- First step toward deprecating `@bigcommerce/handlebars-v4` (this is a published dep of the worker / bundle-service, so it must release first).

## How was it tested?

- `npm test` — 888 tests pass (parity with pre-change baseline).
- `npm run lint` — clean.
- Verified alias resolves: `require('handlebars-v4').VERSION === '4.7.9'` and `handlebars-v4/runtime.js` template fn present; `@bigcommerce/handlebars-v4` absent from `node_modules`.

[TRAC-961]: https://bigcommercecloud.atlassian.net/browse/TRAC-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ