### PR TITLE
fix(TRAC-1339): throw ValidationError for non-string input in urlParse and stripProtocol

### DIFF
--- a/helpers/3p/url.js
+++ b/helpers/3p/url.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var url = require('url');
+var ValidationError = require('../../lib/errors').ValidationError;
 
 /**
  * Expose `helpers`
@@ -58,6 +59,9 @@ helpers.urlResolve = function(base, href) {
  */
 
 helpers.urlParse = function(str) {
+  if (typeof str !== 'string') {
+    throw new ValidationError("Non-string passed to urlParse");
+  }
   return url.parse(str);
 };
 
@@ -75,6 +79,9 @@ helpers.urlParse = function(str) {
  */
 
 helpers.stripProtocol = function(str) {
+  if (typeof str !== 'string') {
+    throw new ValidationError("Non-string passed to stripProtocol");
+  }
   var parsed = url.parse(str);
   delete parsed.protocol;
   return parsed.format();

--- a/spec/helpers/3p/url.js
+++ b/spec/helpers/3p/url.js
@@ -6,6 +6,7 @@ const it = lab.it;
 const describe = lab.describe
 
 const { buildRenderer } = require('../../spec-helpers');
+const { ValidationError } = require('../../../lib/errors');
 const renderer = buildRenderer();
 const hbs = renderer.handlebars;
 const helpers = require('../../../helpers/3p/misc');
@@ -71,6 +72,13 @@ describe('url', function() {
       });
       done();
     });
+
+    it('should throw ValidationError if input is not a string', function(done) {
+      var fn = hbs.compile('{{urlParse testUrl}}');
+      expect(() => fn({ testUrl: undefined })).to.throw(ValidationError, 'Non-string passed to urlParse');
+      expect(() => fn({ testUrl: 123 })).to.throw(ValidationError, 'Non-string passed to urlParse');
+      done();
+    });
   });
 
   describe('strip protocol', function() {
@@ -103,6 +111,13 @@ describe('url', function() {
       var data = { testUrl: testUrl };
       var fn = hbs.compile('{{stripProtocol testUrl}}');
       expect(fn(data)).to.equal(testUrl);
+      done();
+    });
+
+    it('should throw ValidationError if input is not a string', function(done) {
+      var fn = hbs.compile('{{stripProtocol testUrl}}');
+      expect(() => fn({ testUrl: undefined })).to.throw(ValidationError, 'Non-string passed to stripProtocol');
+      expect(() => fn({ testUrl: { foo: 'bar' } })).to.throw(ValidationError, 'Non-string passed to stripProtocol');
       done();
     });
 


### PR DESCRIPTION
Jira: [TRAC-1339](https://bigcommercecloud.atlassian.net/browse/TRAC-1339) (LTRAC-1395)

## What? Why?

- `urlParse` and `stripProtocol` passed input straight to `url.parse()`, so an undefined theme variable threw a raw TypeError and 500'd the whole page render
- Both helpers now throw `ValidationError` for non-string input, which the renderer preserves (#404) so it can surface as a 4xx template error pointing at the theme instead of a 500
- Same pattern as `strReplace` and `encodeHtmlEntities`

## How was it tested?

- Added specs asserting both helpers throw `ValidationError` for undefined, number, and object input
- `npm test` passes (890 tests), coverage 97.66%
- `npm run lint` clean
- Tested in stencil-cli: "Non-string passed to urlParse : Error: Non-string passed to urlParse"

----

cc @bigcommerce/storefront-team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-1339]: https://bigcommercecloud.atlassian.net/browse/TRAC-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ